### PR TITLE
feat(#26): explicit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,16 @@
-
 <center>
-
 <img  src="./assets/comfylang.png"  alt="comfy logo">
-
-</center>
-
-  
-  
+</center>  
 
 **comfy** is a low-level, compiled scripting language with direct [arm32](https://en.wikipedia.org/wiki/ARM_architecture_family#32-bit_architecture) syscall access.
 
-  
-
 ## Features
 
-  
-
 - Direct access to arm32 syscalls
-
 - Simple syntax for low-level programming
-
 - Compiles to arm32 assembly
 
-  
-
-## Example
-
-  
+## Example  
 
 ```
 fn main() {
@@ -35,24 +19,13 @@ fn main() {
   $write(1, hello_text);
   $exit(703);
 }
-
 ```
 
-  
-
-## Currently supported syscalls
-
-  
-
+## Currently supported syscallsi32
 **comfy** provides direct wrappers to arm32 syscalls, stripping away
-
 boilerplate code such as setting up registers manually.
-
 Syscall wrappers are prefixed with `$`.
-
 The following syscalls are currently supported or next in development:
-
-  
 
 | Supported? | Syscall # | Syscall Name | Wrapper Function | Description | Return Value |
 | --- | --- | --- | --- | --- | --- |
@@ -67,17 +40,9 @@ The following syscalls are currently supported or next in development:
   
 
 ## Variables
-
-  
-
 **comfy** supports simple variable declarations using the `let` keyword. Variables can hold string literals, or numbers. They can also be used to refer to empty buffers in memory.
 
-  
-
-### Example
-
-  
-
+### Example  
 ```comfy
 fn main() {
   let text = "hello!\n";
@@ -87,12 +52,8 @@ fn main() {
 }
 ```
 
-  
-
 You can also reference fixed-size buffers using square brackets. This is especially useful for working with `read()` and other syscalls that require writeable memory pointers. Assigning return values to variables in one line is also possible.
-
   
-
 ```comfy
 fn main() {
   buf[128] comfySpace; // Declare a 128-byte buffer

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ fn main() {
 }
 ```
 
-## Currently supported syscallsi32
+## Currently supported syscalls
 **comfy** provides direct wrappers to arm32 syscalls, stripping away
 boilerplate code such as setting up registers manually.
 Syscall wrappers are prefixed with `$`.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@
 ## Features
 
 - Direct access to arm32 syscalls
-- Simple syntax for low-level programming
+- Simple syntax for type-safe, low-level programming
 - Compiles to arm32 assembly
 
 ## Example  
-
+The following example writes `hello comfy!` to stdout and exits with exit code `0`.
 ```
 fn main() {
-  $write(1, "hello comfy!\n");
-  let hello_text = ":3\n";
+  str hello_text = "hello comfy!\n";
   $write(1, hello_text);
-  $exit(703);
+  $exit(0);
 }
 ```
 
@@ -40,26 +39,28 @@ The following syscalls are currently supported or next in development:
   
 
 ## Variables
-**comfy** supports simple variable declarations using the `let` keyword. Variables can hold string literals, or numbers. They can also be used to refer to empty buffers in memory.
+**comfy** uses explicit types, which have to be stated when a variable is initialized. Currently available types are `bool`, `char`, `int8`, `int16`, `int32` and `str`.  
 
 ### Example  
 ```comfy
 fn main() {
-  let text = "hello!\n";
+  str text = "hello!\n";
   $write(1, text);
-  let code = 0;
+
+  int8 code = 0;
   $exit(code);
 }
 ```
 
-You can also reference fixed-size buffers using square brackets. This is especially useful for working with `read()` and other syscalls that require writeable memory pointers. Assigning return values to variables in one line is also possible.
+Variables are immutable by default. To declare a variable as mutable, use the `mut` keyword.
   
 ```comfy
 fn main() {
-  buf[128] comfySpace; // Declare a 128-byte buffer
-  let inputSize = $read(0, comfySpace); // Read from stdin into comfySpace and return the amount of bytes read
-  let code = 0;
-  $exit(code);
+  mut int8 exit_code = 1;
+
+  exit_code = 0;
+
+  $exit(exit_code);
 }
 
 ```

--- a/examples/immutable_buffers.fy
+++ b/examples/immutable_buffers.fy
@@ -1,0 +1,7 @@
+fn main() {
+    // mutable variable 
+    mut int32 changeable;
+
+    // immutable variable
+    int32 unchangeable;
+}

--- a/examples/read_return_test.fy
+++ b/examples/read_return_test.fy
@@ -1,10 +1,13 @@
-
 fn main() {
     $write(1, "hello comfy!\n");
 
     buf[64] text;
     let retSize = $read(0, text);
-    $write(1, text);
+    print_text(text, retSize);
 
-    $exit(69);
+    $exit(0);
+}
+
+fn print_text(buf[64] text, size) {
+    $write(1, text);
 }

--- a/examples/static_types_spectest.fy
+++ b/examples/static_types_spectest.fy
@@ -18,7 +18,7 @@ fn main() {
     o = 13;
 }
 
-fn meow(bool arg1,int8 arg2) {
+fn meow(mut bool arg1,mut int8 arg2) {
     mut bool a;
     mut int8 b;
     mut int16 c;

--- a/examples/static_types_spectest.fy
+++ b/examples/static_types_spectest.fy
@@ -1,0 +1,36 @@
+fn main() {
+    bool a = true;
+    bool b = false;
+
+    int8 e = 12;
+    int16 f = 12;
+    int16 g = 232;
+    int32 h = 12;
+    int32 i = 1234;
+    int32 j = 12345678;
+
+    char k = 'a';
+
+    str m = "hello";
+    str n = "";
+
+    mut int8 o = 12;
+    o = 13;
+}
+
+fn meow(bool arg1,int8 arg2) {
+    mut bool a;
+    mut int8 b;
+    mut int16 c;
+    mut int32 d;
+    mut char e;
+    mut str f;
+}
+
+fn baubau(mut bool arg1) {    
+    mut int8 a = 12;
+    a = 13;
+
+    mut int16 b = 12;
+    b = 13;
+}

--- a/examples/static_types_spectest.fy
+++ b/examples/static_types_spectest.fy
@@ -18,7 +18,7 @@ fn main() {
     o = 13;
 }
 
-fn meow(mut bool arg1,mut int8 arg2) {
+fn meow(mut bool arg1, mut int8 arg2) {
     mut bool a;
     mut int8 b;
     mut int16 c;

--- a/examples/static_types_spectest.fy
+++ b/examples/static_types_spectest.fy
@@ -16,7 +16,7 @@ fn main() {
 
     mut int8 o = 12;
     o = 13;
-
+    
     $exit(o);
 }
 

--- a/examples/static_types_spectest.fy
+++ b/examples/static_types_spectest.fy
@@ -16,6 +16,8 @@ fn main() {
 
     mut int8 o = 12;
     o = 13;
+
+    $exit(o);
 }
 
 fn meow(mut bool arg1, mut int8 arg2) {

--- a/examples/static_types_test.fy
+++ b/examples/static_types_test.fy
@@ -18,7 +18,7 @@ fn main() {
     o = 13;
 }
 
-fn meow(bool arg1,int8 arg2) {
+fn meow(bool arg1, int8 arg2) {
     mut bool a;
     mut int8 b;
     mut int16 c;

--- a/examples/static_types_test.fy
+++ b/examples/static_types_test.fy
@@ -14,3 +14,12 @@ fn main() {
     str m = "hello";
     str n = "";
 }
+
+fn meow(bool arg1, int8 arg2) {
+    bool a;
+    int8 b;
+    int16 c;
+    int32 d;
+    char e;
+    str f;
+}

--- a/examples/static_types_test.fy
+++ b/examples/static_types_test.fy
@@ -23,3 +23,13 @@ fn meow(bool arg1, int8 arg2) {
     char e;
     str f;
 }
+
+fn baubau(mut bool arg1) {
+    arg1 = false;
+    
+    mut int8 a = 12;
+    a = 13;
+
+    mut int16 b = 12;
+    b = 13;
+}

--- a/examples/static_types_test.fy
+++ b/examples/static_types_test.fy
@@ -13,20 +13,21 @@ fn main() {
 
     str m = "hello";
     str n = "";
+
+    mut int8 o = 12;
+    o = 13;
 }
 
-fn meow(bool arg1, int8 arg2) {
-    bool a;
-    int8 b;
-    int16 c;
-    int32 d;
-    char e;
-    str f;
+fn meow(bool arg1,int8 arg2) {
+    mut bool a;
+    mut int8 b;
+    mut int16 c;
+    mut int32 d;
+    mut char e;
+    mut str f;
 }
 
-fn baubau(mut bool arg1) {
-    arg1 = false;
-    
+fn baubau(mut bool arg1) {    
     mut int8 a = 12;
     a = 13;
 

--- a/examples/static_types_test.fy
+++ b/examples/static_types_test.fy
@@ -1,0 +1,16 @@
+fn main() {
+    bool a = true;
+    bool b = false;
+
+    int8 e = 12;
+    int16 f = 12;
+    int16 g = 232;
+    int32 h = 12;
+    int32 i = 1234;
+    int32 j = 12345678;
+
+    char k = 'a';
+
+    str m = "hello";
+    str n = "";
+}

--- a/examples/type_sys_test.fy
+++ b/examples/type_sys_test.fy
@@ -1,0 +1,3 @@
+fn main() {
+    char awda4 = 12;
+}

--- a/examples/typed_syscalls.fy
+++ b/examples/typed_syscalls.fy
@@ -1,0 +1,4 @@
+fn main() {
+    int8 a = 12;
+    $exit(1);
+}

--- a/src/backend/arm32/asm.rs
+++ b/src/backend/arm32/asm.rs
@@ -73,7 +73,6 @@ pub fn syscall_1arg(syscall_number: u32, arg0: &str) -> String {
     )
 }
 
-
 fn into_register_load(value: &str, register: &str) -> String {
     if value.chars().all(|c| c.is_ascii_digit()) {
         format!("mov {}, #{}", register, value)
@@ -90,6 +89,11 @@ pub fn mov_imm(reg: &str, value: usize) -> String {
 #[allow(dead_code)]
 pub fn ldr_label(reg: &str, label: &str) -> String {
     format!("\tldr {}, ={}", reg, label)
+}
+
+#[allow(dead_code)]
+pub fn store_into_reg(reg: &str, reg_to_store_in: usize) -> String {
+    format!("\tstr {}, [{}]\n", reg, reg_to_store_in)
 }
 
 #[allow(dead_code)]
@@ -134,12 +138,8 @@ pub fn load_syscall_return_value_into_reg(text: &mut Vec<String>) {
         reg.as_str(),
         RETURN_VALUE_BUF
     ));
-    
-    text.push(format!(
-        "\tldr {}, [{}]\n",
-        reg.as_str(),
-        reg.as_str()
-    ));
+
+    text.push(format!("\tldr {}, [{}]\n", reg.as_str(), reg.as_str()));
 }
 
 pub fn load_syscall_return_value_into_label(text: &mut Vec<String>, label: &str) {
@@ -164,7 +164,6 @@ pub fn load_syscall_return_value_into_label(text: &mut Vec<String>, label: &str)
     ));
 }
 
-
 // ========== UTILITY FUNCTIONS ==========
 
 pub fn generate_assembly(rodata: Vec<String>, bss: Vec<String>, text: Vec<String>) -> String {
@@ -177,7 +176,10 @@ pub fn generate_assembly(rodata: Vec<String>, bss: Vec<String>, text: Vec<String
     }
 
     assembly_code.push_str("\n.section .bss\n");
-    assembly_code.push_str(&format!("\t.comm {}, {}, {}\n", RETURN_VALUE_BUF, RETURN_VALUE_SIZE, RETURN_VALUE_BUF_ALLIGNMENT));
+    assembly_code.push_str(&format!(
+        "\t.comm {}, {}, {}\n",
+        RETURN_VALUE_BUF, RETURN_VALUE_SIZE, RETURN_VALUE_BUF_ALLIGNMENT
+    ));
     for bss_item in bss.iter() {
         assembly_code.push_str("\t");
         assembly_code.push_str(bss_item.as_str());

--- a/src/backend/arm32/asm.rs
+++ b/src/backend/arm32/asm.rs
@@ -142,6 +142,7 @@ pub fn load_syscall_return_value_into_reg(text: &mut Vec<String>) {
     text.push(format!("\tldr {}, [{}]\n", reg.as_str(), reg.as_str()));
 }
 
+#[allow(dead_code)]
 pub fn load_syscall_return_value_into_label(text: &mut Vec<String>, label: &str) {
     let ptr_reg: Register = Register::R5;
 

--- a/src/backend/arm32/section.rs
+++ b/src/backend/arm32/section.rs
@@ -33,11 +33,13 @@ impl SectionWriter {
         self.bss.push(format!(".lcomm {}, {}", label, size));
     }
 
+    #[allow(dead_code)]
     pub fn declare_bss_with_name_prefix(&mut self, prefix: &str, name: &str, size: i32) {
         self.bss
             .push(format!(".lcomm {}_{}, {}", prefix, name, size));
     }
 
+    #[allow(dead_code)]
     pub fn declare_bss_with_len(&mut self, label: &str, size: i32) {
         self.bss.push(format!(".lcomm {}, {}", label, size));
         self.bss.push(format!("{}_len = {}", label, size));

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -250,7 +250,8 @@ impl Generator {
 
     fn assign_num_variable(&mut self, label: &str, val: usize) {
         self.section_writer.push_text(ldr_label("r0", &label));
-        self.section_writer.push_text(mov_imm("r0", val));
+        self.section_writer.push_text(mov_imm("r1", val));
+        self.section_writer.push_text("str r1, [r0]");
     }
 
     fn store_buffer(&mut self, label: &str, value_type: &Token) {

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -66,7 +66,7 @@ impl Generator {
                 }
             }
 
-            AstNode::VariableDeclaration(name, value) => {
+            AstNode::VariableDeclaration(name, value, _) => { // TODO: handle var_type
                 let label = format!("{}_{}", self.last_fun_name, name);
 
                 match &**value {

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -119,18 +119,18 @@ impl Generator {
 
         let syscall_number: u32 = get_syscall_num_or_panic(self.arch, "write");
         let fd_str = match fd {
-            Token::Number(n) => n.to_string(),
+            Token::Int32Container(n) => n.to_string(),
             Token::Identifier(id) => id.clone(),
             _ => panic!("Unsupported file descriptor type: {:?}", fd),
         };
 
         match data {
-            Token::String(s) => {
+            Token::StrContainer(s) => {
                 let var = generate_str_varname();
                 self.section_writer.push_rodata_str_with_len(&var, s);
 
                 match fd {
-                    Token::Number(n) => {
+                    Token::Int32Container(n) => {
                         let instr = syscall_3args(
                             syscall_number,
                             &n.to_string(),
@@ -191,7 +191,7 @@ impl Generator {
         let syscall_number = get_syscall_num_or_panic(self.arch, "exit");
 
         let asm = match code {
-            Token::Number(n) => syscall_1arg(syscall_number, &n.to_string()),
+            Token::Int32Container(n) => syscall_1arg(syscall_number, &n.to_string()),
             Token::Identifier(id) => syscall_1arg(syscall_number, &id),
             _ => panic!("Unsupported exit code: {:?}", code),
         };

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -55,7 +55,7 @@ impl Generator {
 
                 // Declare params in .bss
                 for param in params {
-                    if let AstNode::Identifier(param_name, size) = param {
+                    if let AstNode::IdentifierWithSize(param_name, size) = param {
                         self.section_writer
                             .declare_bss_with_name_prefix(&fun_name, param_name, *size);
                     }
@@ -85,7 +85,7 @@ impl Generator {
                 }
             }
 
-            AstNode::Identifier(name, size) => {
+            AstNode::IdentifierWithSize(name, size) => {
                 let label = format!("{}_{}", self.last_fun_name, name);
                 self.section_writer.declare_bss_with_len(&label, *size);
             }

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -239,8 +239,9 @@ impl Generator {
         if is_mutable {
             self.section_writer
                 .declare_bss(&label, get_bytes_from_type(value_type));
-            self.section_writer.push_text(ldr_label("r0", &label));
+            self.section_writer.push_text(ldr_label("r1", &label));
             self.section_writer.push_text(mov_imm("r0", val));
+            self.section_writer.push_text("str r0, [r1]");
             return;
         }
 

--- a/src/backend/generator.rs
+++ b/src/backend/generator.rs
@@ -111,14 +111,20 @@ impl Generator {
                 self.store_buffer(&name, value_type);
             }
 
-            AstNode::VariableAssignment(name, value) => match &**value {
-                AstNode::IBool(val) => self.assign_num_variable(&name, if *val { 1 } else { 0 }),
-                AstNode::IChar(val) => self.assign_num_variable(&name, *val as usize),
-                AstNode::IInt8(val) => self.assign_num_variable(&name, *val as usize),
-                AstNode::IInt16(val) => self.assign_num_variable(&name, *val as usize),
-                AstNode::IInt32(val) => self.assign_num_variable(&name, *val as usize),
-                _ => panic!("Unsupported value type in variable assignment: {:?}", value),
-            },
+            AstNode::VariableAssignment(name, value) => {
+                let var_name = format!("{}_{}", self.last_fun_name, name);
+
+                match &**value {
+                    AstNode::IBool(val) => {
+                        self.assign_num_variable(&name, if *val { 1 } else { 0 })
+                    }
+                    AstNode::IChar(val) => self.assign_num_variable(&var_name, *val as usize),
+                    AstNode::IInt8(val) => self.assign_num_variable(&var_name, *val as usize),
+                    AstNode::IInt16(val) => self.assign_num_variable(&var_name, *val as usize),
+                    AstNode::IInt32(val) => self.assign_num_variable(&var_name, *val as usize),
+                    _ => panic!("Unsupported value type in variable assignment: {:?}", value),
+                };
+            }
 
             AstNode::InlineAsm(asm_lines) => {
                 self.section_writer.push_text("\t@ ===Inline Assembly===");

--- a/src/backend/syscalls.rs
+++ b/src/backend/syscalls.rs
@@ -9,28 +9,28 @@ pub fn parse_sys_write(parser: &mut Parser) -> AstNode {
     parser.consume(Token::ParentOpen);
 
     let fd = match parser.current_token() {
-        Token::Number(n) => {
-            parser.consume(Token::Number(n));
-            Token::Number(n)
-        },
+        Token::Int32Container(n) => {
+            parser.consume(Token::Int32Container(n));
+            Token::Int32Container(n)
+        }
         Token::Identifier(id) => {
             parser.consume(Token::Identifier(id.clone()));
             Token::Identifier(id)
-        },
+        }
         _ => panic!("Expected file descriptor (number)"),
     };
 
     parser.consume(Token::Comma);
 
     let write_data = match parser.current_token() {
-        Token::String(s) => {
-            parser.consume(Token::String(s.clone()));
-            Token::String(s)
-        },
+        Token::StrContainer(s) => {
+            parser.consume(Token::StrContainer(s.clone()));
+            Token::StrContainer(s)
+        }
         Token::Identifier(id) => {
             parser.consume(Token::Identifier(id.clone()));
             Token::Identifier(id)
-        },
+        }
         _ => panic!("Expected write data (string or identifier)"),
     };
 
@@ -45,10 +45,10 @@ pub fn parse_sys_read(parser: &mut Parser) -> AstNode {
     parser.consume(Token::ParentOpen);
 
     let fd = match parser.current_token() {
-        Token::Number(n) => n,
+        Token::Int32Container(n) => n,
         _ => panic!("Expected file descriptor (number)"),
     };
-    parser.consume(Token::Number(fd));
+    parser.consume(Token::Int32Container(fd));
 
     parser.consume(Token::Comma);
 
@@ -69,7 +69,7 @@ pub fn parse_sys_exit(parser: &mut Parser) -> AstNode {
     parser.consume(Token::ParentOpen);
 
     let code = match parser.current_token() {
-        Token::Number(n) => Token::Number(n),
+        Token::Int32Container(n) => Token::Int32Container(n),
         Token::Identifier(id) => Token::Identifier(id),
         _ => panic!("Expected exit code (number or identifier)"),
     };
@@ -86,26 +86,26 @@ pub fn parse_sys_open(parser: &mut Parser) -> AstNode {
     parser.consume(Token::ParentOpen);
 
     let filename = match parser.current_token() {
-        Token::String(s) => s,
+        Token::StrContainer(s) => s,
         _ => panic!("Expected filename (string)"),
     };
-    parser.consume(Token::String(filename.clone()));
+    parser.consume(Token::StrContainer(filename.clone()));
 
     parser.consume(Token::Comma);
 
     let flags = match parser.current_token() {
-        Token::Number(n) => n,
+        Token::Int32Container(n) => n,
         _ => panic!("Expected flags (number)"),
     };
-    parser.consume(Token::Number(flags));
+    parser.consume(Token::Int32Container(flags));
 
     parser.consume(Token::Comma);
 
     let mode = match parser.current_token() {
-        Token::Number(n) => n,
+        Token::Int32Container(n) => n,
         _ => panic!("Expected mode (number)"),
     };
-    parser.consume(Token::Number(mode));
+    parser.consume(Token::Int32Container(mode));
 
     parser.consume(Token::ParentClose);
 

--- a/src/backend/syscalls.rs
+++ b/src/backend/syscalls.rs
@@ -8,17 +8,7 @@ pub fn parse_sys_write(parser: &mut Parser) -> AstNode {
 
     parser.consume(Token::ParentOpen);
 
-    let fd = match parser.current_token() {
-        Token::Int32Container(n) => {
-            parser.consume(Token::Int32Container(n));
-            Token::Int32Container(n)
-        }
-        Token::Identifier(id) => {
-            parser.consume(Token::Identifier(id.clone()));
-            Token::Identifier(id)
-        }
-        _ => panic!("Expected file descriptor (number)"),
-    };
+    let fd = parse_int_or_identifier(parser, "file descriptor");
 
     parser.consume(Token::Comma);
 
@@ -44,11 +34,7 @@ pub fn parse_sys_read(parser: &mut Parser) -> AstNode {
 
     parser.consume(Token::ParentOpen);
 
-    let fd = match parser.current_token() {
-        Token::Int32Container(n) => n,
-        _ => panic!("Expected file descriptor (number)"),
-    };
-    parser.consume(Token::Int32Container(fd));
+    let fd = parse_int_or_identifier(parser, "file descriptor");
 
     parser.consume(Token::Comma);
 
@@ -60,7 +46,7 @@ pub fn parse_sys_read(parser: &mut Parser) -> AstNode {
     parser.consume(Token::Identifier(buffer.clone()));
     parser.consume(Token::ParentClose);
 
-    AstNode::Read(fd as usize, buffer)
+    AstNode::Read(fd, buffer)
 }
 
 pub fn parse_sys_exit(parser: &mut Parser) -> AstNode {
@@ -68,15 +54,9 @@ pub fn parse_sys_exit(parser: &mut Parser) -> AstNode {
 
     parser.consume(Token::ParentOpen);
 
-    let code = match parser.current_token() {
-        Token::Int32Container(n) => Token::Int32Container(n),
-        Token::Identifier(id) => Token::Identifier(id),
-        _ => panic!("Expected exit code (number or identifier)"),
-    };
-    parser.consume(code.clone());
+    let code = parse_int_or_identifier(parser, "exit code");
 
     parser.consume(Token::ParentClose);
-
     AstNode::Exit(code)
 }
 
@@ -87,6 +67,7 @@ pub fn parse_sys_open(parser: &mut Parser) -> AstNode {
 
     let filename = match parser.current_token() {
         Token::StrContainer(s) => s,
+        Token::Identifier(id) => id,
         _ => panic!("Expected filename (string)"),
     };
     parser.consume(Token::StrContainer(filename.clone()));
@@ -94,18 +75,38 @@ pub fn parse_sys_open(parser: &mut Parser) -> AstNode {
     parser.consume(Token::Comma);
 
     let flags = match parser.current_token() {
-        Token::Int32Container(n) => n,
+        Token::Int32Container(n) => {
+            parser.consume(Token::Int32Container(n));
+            n
+        }
+        Token::Int16Container(n) => {
+            parser.consume(Token::Int16Container(n));
+            i32::from(n)
+        }
+        Token::Int8Container(n) => {
+            parser.consume(Token::Int8Container(n));
+            i32::from(n)
+        }
         _ => panic!("Expected flags (number)"),
     };
-    parser.consume(Token::Int32Container(flags));
 
     parser.consume(Token::Comma);
 
     let mode = match parser.current_token() {
-        Token::Int32Container(n) => n,
+        Token::Int32Container(n) => {
+            parser.consume(Token::Int32Container(n));
+            n
+        }
+        Token::Int16Container(n) => {
+            parser.consume(Token::Int16Container(n));
+            i32::from(n)
+        }
+        Token::Int8Container(n) => {
+            parser.consume(Token::Int8Container(n));
+            i32::from(n)
+        }
         _ => panic!("Expected mode (number)"),
     };
-    parser.consume(Token::Int32Container(mode));
 
     parser.consume(Token::ParentClose);
 
@@ -126,4 +127,17 @@ pub fn parse_sys_sysinfo(parser: &mut Parser) -> AstNode {
     parser.consume(Token::ParentClose);
 
     AstNode::Sysinfo(buffer)
+}
+
+fn parse_int_or_identifier(parser: &mut Parser, context: &str) -> Token {
+    match parser.current_token() {
+        token @ Token::Int32Container(_)
+        | token @ Token::Int16Container(_)
+        | token @ Token::Int8Container(_)
+        | token @ Token::Identifier(_) => {
+            parser.consume(token.clone());
+            token.clone()
+        }
+        _ => panic!("Expected {} (number or identifier)", context),
+    }
 }

--- a/src/extra/utils.rs
+++ b/src/extra/utils.rs
@@ -1,5 +1,7 @@
 use rand::Rng;
 
+use crate::frontend::tokenizer::Token;
+
 fn generate_random_alphanumeric_string(length: usize) -> String {
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                              abcdefghijklmnopqrstuvwxyz\
@@ -27,6 +29,14 @@ pub fn generate_str_varname() -> String {
     name
 }
 
-pub fn get_bytes_from_type() {
-    // TODO: 
+pub fn get_bytes_from_type(token: &Token) -> usize {
+    match token {
+        Token::Bool => 1,
+        Token::Char => 1,
+        Token::Int8 => 1,
+        Token::Int16 => 2,
+        Token::Int32 => 4,
+        Token::Str => 4, // Assuming a pointer size for strings
+        _ => panic!("Unsupported type for byte size calculation: {:?}", token),
+    }
 }

--- a/src/extra/utils.rs
+++ b/src/extra/utils.rs
@@ -26,3 +26,7 @@ pub fn generate_str_varname() -> String {
     name.push_str(&generate_random_alphanumeric_string(8));
     name
 }
+
+pub fn get_bytes_from_type() {
+    // TODO: 
+}

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -17,7 +17,7 @@ pub enum AstNode {
     VariableAssignment(String, Box<AstNode>),
     InlineAsm(Vec<String>),
 
-    // Token::Bool, mutable?
+    // Token::Bool, isMutable?
     Type(Token, bool),
 
     // syscall wrappers

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -188,7 +188,7 @@ impl Parser {
             // variable assignment
             Token::Equals => self.parse_variable_assignment(identifier),
             // function call
-            Token::ParentOpen => todo!(),
+            Token::ParentOpen => panic!("Function call parsing not implemented yet"),
             _ => panic!("Expected '=' or '(', found: {:?}", self.current_token()),
         }
     }

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -8,7 +8,7 @@ pub enum AstNode {
     Program(Vec<AstNode>),
     Identifier(String, Token),
     FunctionDefinition(String, Vec<AstNode>, Vec<AstNode>),
-    VariableDeclaration(String, Box<AstNode>),
+    VariableDeclaration(String, Box<AstNode>, Token),
     VariableBufferDeclaration(String, Token),
     InlineAsm(Vec<String>),
 
@@ -138,7 +138,7 @@ impl Parser {
 
         self.consume(Token::Semicolon);
 
-        AstNode::VariableDeclaration(identifier, Box::new(value))
+        AstNode::VariableDeclaration(identifier, Box::new(value), var_type)
     }
 
     fn parse_statement(&mut self) -> AstNode {

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -1,5 +1,3 @@
-use serde::de::value::I8Deserializer;
-
 use crate::{
     backend::syscalls::{
         parse_sys_exit, parse_sys_open, parse_sys_read, parse_sys_sysinfo, parse_sys_write,
@@ -10,7 +8,7 @@ use crate::{
 #[derive(Debug)]
 pub enum AstNode {
     Program(Vec<AstNode>),
-    Identifier(String, Box<AstNode>),
+    _Identifier(String, Box<AstNode>),
     FunctionDefinition(String, Vec<AstNode>, Vec<AstNode>),
     VariableDeclaration(String, Box<AstNode>, Box<AstNode>),
     VariableBufferDeclaration(String, Box<AstNode>),

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -35,11 +35,6 @@ pub enum AstNode {
     IInt8(i8),
     IInt16(i16),
     IInt32(i32),
-
-    // deprecated
-    Number(i32),
-    IdentifierWithSize(String, i32),
-    String(String),
 }
 
 pub fn parse(tokens: Vec<Token>) -> AstNode {
@@ -350,7 +345,7 @@ impl Parser {
 
         let identifier = self.consume_identifier();
 
-        AstNode::Identifier(identifier, Box::new(AstNode::Type(param_type, mutable)))
+        AstNode::VariableBufferDeclaration(identifier, Box::new(AstNode::Type(param_type, mutable)))
     }
 
     fn parse_inline_asm(&mut self) -> AstNode {

--- a/src/frontend/parser.rs
+++ b/src/frontend/parser.rs
@@ -21,7 +21,7 @@ pub enum AstNode {
     // syscall wrappers
     Syscall(String, Box<AstNode>),
     Write(Token, Token),
-    Read(usize, String),
+    Read(Token, String),
     Open(String, usize, usize),
     Exit(Token),
     Sysinfo(String),

--- a/src/frontend/tokenizer.rs
+++ b/src/frontend/tokenizer.rs
@@ -82,7 +82,7 @@ pub fn tokenize(script: &str) -> Vec<Token> {
             }
 
             '\'' => {
-                if let Some(_) = iter.peek() {
+                if iter.peek().is_some() {
                     let ch = iter.next().unwrap(); // Consume the character
                     if let Some(&closing_quote) = iter.peek() {
                         if closing_quote == '\'' {

--- a/src/frontend/tokenizer.rs
+++ b/src/frontend/tokenizer.rs
@@ -11,6 +11,7 @@ pub enum Token {
     Semicolon,
     Colon,
     Equals,
+    Mut,
 
     BracketOpen,
     BracketClose,
@@ -111,6 +112,7 @@ pub fn tokenize(script: &str) -> Vec<Token> {
                 match identifier.as_str() {
                     "fn" => tokens.push(Token::Function),
                     "asm" => tokens.push(Token::InlineAsm),
+                    "mut" => tokens.push(Token::Mut),
                     "true" => tokens.push(Token::BoolContainer(true)),
                     "false" => tokens.push(Token::BoolContainer(false)),
                     "bool" => tokens.push(Token::Bool),

--- a/src/frontend/tokenizer.rs
+++ b/src/frontend/tokenizer.rs
@@ -34,9 +34,6 @@ pub enum Token {
     Int8Container(i8),
     Int16Container(i16),
     Int32Container(i32),
-
-    Number(i32),
-    String(String),
 }
 
 pub fn tokenize(script: &str) -> Vec<Token> {

--- a/src/frontend/tokenizer.rs
+++ b/src/frontend/tokenizer.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq )]
 pub enum Token {
     Function,
     Identifier(String),

--- a/src/frontend/tokenizer.rs
+++ b/src/frontend/tokenizer.rs
@@ -1,8 +1,5 @@
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
-    Number(i32),
-    String(String),
-
     Function,
     Identifier(String),
     Syscall(String),
@@ -14,14 +11,31 @@ pub enum Token {
     Semicolon,
     Colon,
     Equals,
-    Let,
-    Buf,
+
     BracketOpen,
     BracketClose,
     InlineAsm,
 
-    EOF, // End of File
+    EOF,
     Unknown,
+
+    // comfy base types
+    TypeDefBool,
+    TypeDefChar,
+    TypeDefStr,
+    TypeDefInt8,
+    TypeDefInt16,
+    TypeDefInt32,
+    Bool(bool),
+    Char(char),
+    Str(String),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+
+    // deprecated
+    Number(i32),
+    String(String),
 }
 
 pub fn tokenize(script: &str) -> Vec<Token> {
@@ -65,7 +79,21 @@ pub fn tokenize(script: &str) -> Vec<Token> {
                         string.push(iter.next().unwrap());
                     }
                 }
-                tokens.push(Token::String(string));
+                tokens.push(Token::Str(string));
+            }
+
+            '\'' => {
+                if let Some(&next_ch) = iter.peek() {
+                    iter.next(); // Consume the character
+                    if next_ch == '\'' {
+                        tokens.push(Token::Char('\'')); // Empty char
+                    } else {
+                        tokens.push(Token::Char(next_ch));
+                        iter.next(); // Consume the character
+                    }
+                } else {
+                    tokens.push(Token::Unknown); // Unmatched quote
+                }
             }
 
             c if c.is_alphabetic() || c == '_' => {
@@ -80,9 +108,15 @@ pub fn tokenize(script: &str) -> Vec<Token> {
 
                 match identifier.as_str() {
                     "fn" => tokens.push(Token::Function),
-                    "let" => tokens.push(Token::Let),
-                    "buf" => tokens.push(Token::Buf),
                     "asm" => tokens.push(Token::InlineAsm),
+                    "true" => tokens.push(Token::Bool(true)),
+                    "false" => tokens.push(Token::Bool(false)),
+                    "bool" => tokens.push(Token::TypeDefBool),
+                    "char" => tokens.push(Token::TypeDefChar),
+                    "str" => tokens.push(Token::TypeDefStr),
+                    "int8" => tokens.push(Token::TypeDefInt8),
+                    "int16" => tokens.push(Token::TypeDefInt16),
+                    "int32" => tokens.push(Token::TypeDefInt32),
                     _ => tokens.push(Token::Identifier(identifier)),
                 }
             }
@@ -96,7 +130,17 @@ pub fn tokenize(script: &str) -> Vec<Token> {
                         break;
                     }
                 }
-                tokens.push(Token::Number(number.parse().unwrap()));
+
+                let num_value = number.parse::<i32>().unwrap();
+                match num_value {
+                    n if n >= i8::MIN as i32 && n <= i8::MAX as i32 => {
+                        tokens.push(Token::Int8(n as i8))
+                    }
+                    n if n >= i16::MIN as i32 && n <= i16::MAX as i32 => {
+                        tokens.push(Token::Int16(n as i16))
+                    }
+                    _ => tokens.push(Token::Int32(num_value)),
+                }
             }
 
             _ => tokens.push(Token::Unknown),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,11 +56,15 @@ fn main() {
     let verbose = args.get(2).map_or(false, |arg| arg == "--verbose");
 
     let tokens = tokenize(&preprocessed_content);
+    if verbose {
+        println!("Tokens: {:#?}", tokens);
+    }
     let ast_nodes = parse(tokens.clone());
     if verbose {
-        println!("AST Nodes: {:?}", ast_nodes);
-        println!("Tokens: {:?}", tokens);
+        println!("AST Nodes: {:#?}", ast_nodes);
     }
+
+    return;
 
     let generator = generate(&ast_nodes, arch);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,6 @@ fn main() {
         println!("AST Nodes: {:#?}", ast_nodes);
     }
 
-    return;
-
     let generator = generate(&ast_nodes, arch);
 
     let assembly_code = arm32::asm::generate_assembly(


### PR DESCRIPTION
adds statically typed variables.

removes both the `let` and the `buf` keyword in favor of new, predictably-sized types:
`char`
`bool`
`int8`
`int16`
`int32`
`str`