### PR TITLE
feat(#133): structs implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ util/host-run.sh build/main
 util/run.sh examples/exit_code.cfy
 ```
 
-## Current language surface
+## Examples
 
-`fn main()` plus any number of user-defined functions, with variables, arithmetic, comparisons, `if`/`else`/`while`, and syscalls:
+**Control flow & recursion:**
 
 ```rust
 // examples/showcase.cfy
@@ -37,54 +37,75 @@ fn factorial(n: int) -> int {
     return n * factorial(n - 1);
 }
 
-fn sum_up_to(n: int, out: *int) {
-    let mut i = 1;
-    let mut total = 0;
-    while i <= n {
-        total = total + i;
-        i = i + 1;
-    }
-    *out = total;
-}
-
 fn main() {
-    let mut sum = 0;
-    sum_up_to(5, &sum); // sum = 1+2+3+4+5 = 15
-
-    let fact = factorial(4); // 24
-
-    let mut nums = [10, 20, 30, 40];
-    nums[1] = 25;
-    let extra = nums[0] + nums[1] + nums[2] + nums[3]; // 10+25+30+40 = 105
-
     let mut code = 0;
-    if sum > 10 && fact >= 20 {
-        code = sum + fact + extra; // 144
-    } else if sum == 0 || !(fact < 0) {
-        code = 1;
+    if factorial(4) >= 20 && !(factorial(4) < 0) {
+        code = factorial(4); // 24
     }
-
-    $syscall(1, code, 0, 0, 0, 0, 0); // exit 144
+    $syscall(1, code, 0, 0, 0, 0, 0); // exit 24
 }
 ```
 
-- `let NAME = expr;` is an immutable binding. When `expr` is provably constant it's folded away entirely (zero runtime cost); otherwise it falls back to a real, immutable stack slot. `let mut NAME = expr;` is always a real stack-allocated local that can be reassigned with `NAME = expr;`.
-- Arithmetic (`+ - * / %`, unary `-`) is constant-folded when possible; runtime arithmetic falls back to a simple stack-machine codegen. Runtime (non-constant) `/` and `%` aren't supported yet - arm32 has no hardware divide instruction and the compiler is `-nostdlib`, so it can't call into libgcc for a software fallback.
-- Comparisons (`== != < <= > >=`) produce a real `bool`, and can't be chained (`a < b < c` doesn't parse). `if`/`while` conditions must be `bool`; comfy does not implicitly convert integers to booleans.
-- Functions take typed parameters (`int`/`bool` so far) and an optional `-> Type` return; omitting it means the function returns `()`. Functions must end with a `return` statement if they return a value. Calls follow the AAPCS calling convention (up to 4 arguments in `r0`-`r3`, return value in `r0`) and recursion works.
-- `$syscall(nr, a0, a1, a2, a3, a4, a5)` is the sole compiler intrinsic, usable as a statement or an expression (its return value, from `r0`, can be captured). It maps directly onto the Linux ARM EABI syscall convention. Named wrappers like `write`/`read`/`exit` will come back as ordinary standard-library functions built on top of this, once comfylang has a standard library.
-- `*T` is a pointer to `T` (recursive, e.g. `**T`). `&x` takes the address of a local (only bare identifiers so far); `*p` dereferences, and works both to read (`let y = *p;`) and, as the direct target of `=`, to write (`*p = v;`). `$syscall` arguments may be pointers as well as integers, for passing buffer addresses.
-- `[T; N]` is a fixed-size array of `T`. Array literals (`[e1, e2, ...]`) are the only way to create one right now, and only as a `let`/`let mut` initializer (not a general expression yet); the length and element type are inferred from the literal. Indexing (`arr[i]`) works for both reads and, on a `mut` array, writes (`arr[i] = v;`) - the address is computed at runtime (`base + i * elem_size`), with no bounds checking yet. Arrays live as locals only for now, not as function parameters or return values.
+**Structs, arrays & pointers:**
+
+```rust
+// examples/structs/nested.cfy (trimmed)
+struct Point {
+    x: int,
+    y: int,
+}
+
+fn main() {
+    let mut p = Point { x: 1, y: 2 };
+    p.x = p.x + 4; // 5
+
+    let mut nums = [10, 20, 30];
+    nums[1] = 99;
+
+    let mut total = 0;
+    let mut out = &total;
+    *out = p.x + p.y + nums[0] + nums[1] + nums[2]; // 5+2+10+99+30 = 146
+
+    $syscall(1, total, 0, 0, 0, 0, 0); // exit 146
+}
+```
 
 More examples in [`examples/`](./examples).
 
-## Design goals
+## Language reference
 
-- Manual memory management, structs, pointers, full type safety.
-- Turing-complete, self-hosted: the compiler will eventually be rewritten in comfylang itself.
-- Hand-written backend, ARM32 first, with x86 and others planned via a `Backend` trait.
-- Compile-time optimizations (constant folding, dead-code elimination, and more) once an IR exists.
-- A custom package manager down the line, managing both compiler versions and dependencies.
+**Variables**
+- `let NAME = expr;` is an immutable binding. When `expr` is provably constant it's folded away entirely (zero runtime cost); otherwise it falls back to a real, immutable stack slot.
+- `let mut NAME = expr;` is always a real stack-allocated local that can be reassigned with `NAME = expr;`.
+
+**Arithmetic & comparisons**
+- `+ - * / %` and unary `-` are constant-folded when possible; runtime arithmetic falls back to a simple stack-machine codegen. Runtime (non-constant) `/` and `%` aren't supported yet - arm32 has no hardware divide instruction and the compiler is `-nostdlib`, so it can't call into libgcc for a software fallback.
+- `== != < <= > >=` produce a real `bool`, and can't be chained (`a < b < c` doesn't parse).
+
+**Control flow**
+- `if`/`else`/`else if`, `while`. Conditions must be `bool` - comfy does not implicitly convert integers to booleans.
+- `&& || !` are genuine short-circuiting logical operators.
+
+**Functions**
+- Typed parameters (`int`/`bool` so far) and an optional `-> Type` return; omitting it means the function returns `()`.
+- Functions must end with a `return` statement if they return a value. Calls follow the AAPCS calling convention (up to 4 arguments in `r0`-`r3`, return value in `r0`), and recursion works.
+
+**Pointers**
+- `*T` is a pointer to `T` (recursive, e.g. `**T`).
+- `&x` takes the address of a local (only bare identifiers so far); `*p` dereferences, and works both to read (`let y = *p;`) and, as the direct target of `=`, to write (`*p = v;`).
+
+**Arrays**
+- `[T; N]` is a fixed-size array of `T`. Array literals (`[e1, e2, ...]`) are the only way to create one, and only as a `let`/`let mut` initializer (not a general expression yet); length and element type are inferred from the literal.
+- Indexing (`arr[i]`) works for both reads and, on a `mut` array, writes (`arr[i] = v;`) - the address is computed at runtime (`base + i * elem_size`), with no bounds checking yet. Locals only, not function parameters or return values.
+
+**Structs**
+- `struct Name { field: Type, ... }` declares a struct, forward-declared like functions (order-independent).
+- Struct literals (`Name { field: value, ... }`) work like array literals - only as a `let`/`let mut` initializer, fields in any order but all required.
+- Field access (`s.field`, chainable as `s.a.b.c`) works for reads and, on a `mut` struct, writes, and composes with arrays (`s.arr[i]`).
+- A struct can't contain itself by value (infinite size) - only through a pointer (`*Name`), same as recursive data structures in C. Locals only, not function parameters or return values.
+
+**Syscalls**
+- `$syscall(nr, a0, a1, a2, a3, a4, a5)` is the sole compiler intrinsic, usable as a statement or an expression (its return value, from `r0`, can be captured). It maps directly onto the Linux ARM EABI syscall convention. Arguments may be pointers as well as integers, for passing buffer addresses. Named wrappers like `write`/`read`/`exit` will come back as ordinary standard-library functions once comfylang has a standard library.
 
 ## Roadmap
 
@@ -98,6 +119,6 @@ Planned, in rough order:
 6. ~~User-defined functions, calling convention, recursion~~ ✅
 7. ~~Pointers (`*T`, `&x`, `*p`)~~ ✅
 8. ~~Arrays (`[T; N]`, indexing)~~ ✅
-9. `struct`s
+9. ~~`struct`s~~ ✅
 10. IR + optimization passes
 11. Additional backends (x86_64, ...), standard library, self-hosting prep

--- a/examples/structs/array_field.cfy
+++ b/examples/structs/array_field.cfy
@@ -1,0 +1,22 @@
+struct Buffer {
+    data: [int; 3],
+    len: int,
+}
+
+fn main() {
+    let mut buf = Buffer {
+        data: [10, 20, 30],
+        len: 3,
+    };
+
+    buf.data[1] = 99;
+
+    let mut sum = 0;
+    let mut i = 0;
+    while i < buf.len {
+        sum = sum + buf.data[i];
+        i = i + 1;
+    }
+
+    $syscall(1, sum, 0, 0, 0, 0, 0); // exit 10+99+30 = 139
+}

--- a/examples/structs/nested.cfy
+++ b/examples/structs/nested.cfy
@@ -1,0 +1,22 @@
+struct Point {
+    x: int,
+    y: int,
+}
+
+struct Rect {
+    origin: Point,
+    size: Point,
+}
+
+fn main() {
+    let mut r = Rect {
+        origin: Point { x: 1, y: 2 },
+        size: Point { x: 10, y: 20 },
+    };
+
+    r.origin.x = r.origin.x + 4; // 5
+    r.size.y = r.size.y - 5;     // 15
+
+    let code = r.origin.x + r.origin.y + r.size.x + r.size.y; // 5+2+10+15 = 32
+    $syscall(1, code, 0, 0, 0, 0, 0); // exit 32
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -101,6 +101,16 @@ pub enum Expr {
         index: Box<Expr>,
         span: Span,
     },
+    StructLit {
+        name: String,
+        fields: Vec<(String, Expr)>,
+        span: Span,
+    },
+    Field {
+        base: Box<Expr>,
+        field: String,
+        span: Span,
+    },
 }
 
 impl Expr {
@@ -118,6 +128,8 @@ impl Expr {
             Expr::AddressOf { span, .. } => *span,
             Expr::ArrayLit { span, .. } => *span,
             Expr::Index { span, .. } => *span,
+            Expr::StructLit { span, .. } => *span,
+            Expr::Field { span, .. } => *span,
         }
     }
 }
@@ -126,6 +138,7 @@ pub enum AssignTarget {
     Name(String),
     Deref(Expr),
     Index { base: Expr, index: Expr },
+    Field { base: Expr, field: String },
 }
 
 pub enum Stmt {
@@ -197,6 +210,19 @@ pub struct FunctionDef {
     pub span: Span,
 }
 
+pub struct FieldDef {
+    pub name: String,
+    pub ty: TypeName,
+    pub span: Span,
+}
+
+pub struct StructDef {
+    pub name: String,
+    pub fields: Vec<FieldDef>,
+    pub span: Span,
+}
+
 pub struct Program {
+    pub structs: Vec<StructDef>,
     pub functions: Vec<FunctionDef>,
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,6 +5,7 @@ use crate::diag::{Diagnostic, Span};
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
     Fn,
+    Struct,
     Let,
     Mut,
     If,
@@ -187,6 +188,7 @@ pub fn lex(source: &str) -> Result<Vec<Token>, Diagnostic> {
                 let text = &source[start..i];
                 let kind = match text {
                     "fn" => TokenKind::Fn,
+                    "struct" => TokenKind::Struct,
                     "let" => TokenKind::Let,
                     "mut" => TokenKind::Mut,
                     "if" => TokenKind::If,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -25,6 +25,7 @@ pub enum TokenKind {
     RBracket,
     Comma,
     Colon,
+    Dot,
     Semicolon,
     Equals,
     EqEq,
@@ -80,6 +81,7 @@ pub fn lex(source: &str) -> Result<Vec<Token>, Diagnostic> {
             ']' => push(&mut tokens, TokenKind::RBracket, &mut i, 1),
             ',' => push(&mut tokens, TokenKind::Comma, &mut i, 1),
             ':' => push(&mut tokens, TokenKind::Colon, &mut i, 1),
+            '.' => push(&mut tokens, TokenKind::Dot, &mut i, 1),
             ';' => push(&mut tokens, TokenKind::Semicolon, &mut i, 1),
             '=' => {
                 if bytes.get(i + 1) == Some(&b'=') {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,25 +1,36 @@
 use crate::ast::{
-    AssignTarget, BinOp, CompareOp, Expr, FunctionDef, LogicalOp, Param, Program, Stmt, TypeName,
-    UnaryOp,
+    AssignTarget, BinOp, CompareOp, Expr, FieldDef, FunctionDef, LogicalOp, Param, Program, Stmt,
+    StructDef, TypeName, UnaryOp,
 };
 use crate::diag::{Diagnostic, Span};
 use crate::lexer::{Token, TokenKind};
 
 pub fn parse(tokens: &[Token]) -> Result<Program, Diagnostic> {
-    Parser { tokens, pos: 0 }.parse_program()
+    Parser {
+        tokens,
+        pos: 0,
+        no_struct_literal: false,
+    }
+    .parse_program()
 }
 
 struct Parser<'a> {
     tokens: &'a [Token],
     pos: usize,
+    no_struct_literal: bool,
 }
 
 impl<'a> Parser<'a> {
     fn parse_program(&mut self) -> Result<Program, Diagnostic> {
+        let mut structs = Vec::new();
         let mut functions = Vec::new();
 
         while !self.at(&TokenKind::Eof) {
-            functions.push(self.parse_function()?);
+            if self.at(&TokenKind::Struct) {
+                structs.push(self.parse_struct_def()?);
+            } else {
+                functions.push(self.parse_function()?);
+            }
         }
 
         if functions.is_empty() {
@@ -29,7 +40,36 @@ impl<'a> Parser<'a> {
             ));
         }
 
-        Ok(Program { functions })
+        Ok(Program { structs, functions })
+    }
+
+    /// Runs `f` with bare struct literals forbidden - used while parsing an
+    /// `if`/`while` condition, since `if p == Point { ... }` would otherwise
+    /// be ambiguous with the following block.
+    fn disallowing_struct_literal<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, Diagnostic>,
+    ) -> Result<T, Diagnostic> {
+        let previous = self.no_struct_literal;
+        self.no_struct_literal = true;
+        let result = f(self);
+        self.no_struct_literal = previous;
+        result
+    }
+
+    /// Runs `f` with the restriction lifted again - used whenever we enter
+    /// an unambiguous bracketed/parenthesized sub-context (so struct
+    /// literals still work *inside* parens/calls/brackets even within an
+    /// `if`/`while` condition).
+    fn allowing_struct_literal<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, Diagnostic>,
+    ) -> Result<T, Diagnostic> {
+        let previous = self.no_struct_literal;
+        self.no_struct_literal = false;
+        let result = f(self);
+        self.no_struct_literal = previous;
+        result
     }
 
     fn parse_function(&mut self) -> Result<FunctionDef, Diagnostic> {
@@ -64,6 +104,41 @@ impl<'a> Parser<'a> {
             params,
             return_type,
             body,
+            span: start.to(end),
+        })
+    }
+
+    fn parse_struct_def(&mut self) -> Result<StructDef, Diagnostic> {
+        let start = self.span();
+        self.expect(&TokenKind::Struct)?;
+        let name = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut fields = Vec::new();
+        while !self.at(&TokenKind::RBrace) {
+            let field_start = self.span();
+            let field_name = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let ty = self.parse_type_name()?;
+            let field_end = ty.span();
+            fields.push(FieldDef {
+                name: field_name,
+                ty,
+                span: field_start.to(field_end),
+            });
+            if self.at(&TokenKind::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        let end = self.span();
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(StructDef {
+            name,
+            fields,
             span: start.to(end),
         })
     }
@@ -204,6 +279,7 @@ impl<'a> Parser<'a> {
                 base: *base,
                 index: *index,
             }),
+            Expr::Field { base, field, .. } => Ok(AssignTarget::Field { base: *base, field }),
             other => {
                 let span = other.span();
                 Err(Diagnostic::error("invalid assignment target", span))
@@ -214,7 +290,7 @@ impl<'a> Parser<'a> {
     fn parse_if_stmt(&mut self) -> Result<Stmt, Diagnostic> {
         let start = self.span();
         self.expect(&TokenKind::If)?;
-        let cond = self.parse_expr()?;
+        let cond = self.disallowing_struct_literal(|p| p.parse_expr())?;
         let (then_body, mut end) = self.parse_block()?;
 
         let else_body = if self.at(&TokenKind::Else) {
@@ -243,7 +319,7 @@ impl<'a> Parser<'a> {
     fn parse_while_stmt(&mut self) -> Result<Stmt, Diagnostic> {
         let start = self.span();
         self.expect(&TokenKind::While)?;
-        let cond = self.parse_expr()?;
+        let cond = self.disallowing_struct_literal(|p| p.parse_expr())?;
         let (body, end) = self.parse_block()?;
 
         Ok(Stmt::While {
@@ -287,7 +363,7 @@ impl<'a> Parser<'a> {
 
         let mut args = Vec::new();
         while !self.at(&TokenKind::RParen) {
-            args.push(self.parse_expr()?);
+            args.push(self.allowing_struct_literal(|p| p.parse_expr())?);
             if self.at(&TokenKind::Comma) {
                 self.advance();
             } else {
@@ -468,22 +544,33 @@ impl<'a> Parser<'a> {
         self.parse_postfix()
     }
 
-    /// Consumes a primary expression, then repeatedly folds in any
-    /// following `[index]` - e.g. `arr[i]`, or (once nested arrays exist)
-    /// `arr[i][j]`.
     fn parse_postfix(&mut self) -> Result<Expr, Diagnostic> {
         let mut expr = self.parse_primary()?;
-        while self.at(&TokenKind::LBracket) {
-            let start = expr.span();
-            self.advance();
-            let index = self.parse_expr()?;
-            let end = self.span();
-            self.expect(&TokenKind::RBracket)?;
-            expr = Expr::Index {
-                base: Box::new(expr),
-                index: Box::new(index),
-                span: start.to(end),
-            };
+        loop {
+            if self.at(&TokenKind::LBracket) {
+                let start = expr.span();
+                self.advance();
+                let index = self.allowing_struct_literal(|p| p.parse_expr())?;
+                let end = self.span();
+                self.expect(&TokenKind::RBracket)?;
+                expr = Expr::Index {
+                    base: Box::new(expr),
+                    index: Box::new(index),
+                    span: start.to(end),
+                };
+            } else if self.at(&TokenKind::Dot) {
+                let start = expr.span();
+                self.advance();
+                let field_span = self.span();
+                let field = self.expect_ident()?;
+                expr = Expr::Field {
+                    base: Box::new(expr),
+                    field,
+                    span: start.to(field_span),
+                };
+            } else {
+                break;
+            }
         }
         Ok(expr)
     }
@@ -501,13 +588,15 @@ impl<'a> Parser<'a> {
                 self.advance();
                 if self.at(&TokenKind::LParen) {
                     self.parse_call_args(name, span)
+                } else if self.at(&TokenKind::LBrace) && !self.no_struct_literal {
+                    self.parse_struct_lit(name, span)
                 } else {
                     Ok(Expr::Ident(name, span))
                 }
             }
             TokenKind::LParen => {
                 self.advance();
-                let inner = self.parse_expr()?;
+                let inner = self.allowing_struct_literal(|p| p.parse_expr())?;
                 self.expect(&TokenKind::RParen)?;
                 Ok(inner)
             }
@@ -515,7 +604,7 @@ impl<'a> Parser<'a> {
                 self.advance();
                 let mut elements = Vec::new();
                 while !self.at(&TokenKind::RBracket) {
-                    elements.push(self.parse_expr()?);
+                    elements.push(self.allowing_struct_literal(|p| p.parse_expr())?);
                     if self.at(&TokenKind::Comma) {
                         self.advance();
                     } else {
@@ -562,7 +651,7 @@ impl<'a> Parser<'a> {
 
         let mut args = Vec::new();
         while !self.at(&TokenKind::RParen) {
-            args.push(self.parse_expr()?);
+            args.push(self.allowing_struct_literal(|p| p.parse_expr())?);
             if self.at(&TokenKind::Comma) {
                 self.advance();
             } else {
@@ -576,6 +665,32 @@ impl<'a> Parser<'a> {
         Ok(Expr::Call {
             name,
             args,
+            span: start.to(end),
+        })
+    }
+
+    fn parse_struct_lit(&mut self, name: String, start: Span) -> Result<Expr, Diagnostic> {
+        self.expect(&TokenKind::LBrace)?;
+
+        let mut fields = Vec::new();
+        while !self.at(&TokenKind::RBrace) {
+            let field_name = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let value = self.allowing_struct_literal(|p| p.parse_expr())?;
+            fields.push((field_name, value));
+            if self.at(&TokenKind::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        let end = self.span();
+        self.expect(&TokenKind::RBrace)?;
+
+        Ok(Expr::StructLit {
+            name,
+            fields,
             span: start.to(end),
         })
     }

--- a/src/sema.rs
+++ b/src/sema.rs
@@ -16,6 +16,7 @@ pub enum Ty {
     Unit,
     Pointer(Box<Ty>),
     Array(Box<Ty>, u32),
+    Struct(String),
 }
 
 impl std::fmt::Display for Ty {
@@ -26,33 +27,291 @@ impl std::fmt::Display for Ty {
             Ty::Unit => write!(f, "()"),
             Ty::Pointer(inner) => write!(f, "*{}", inner),
             Ty::Array(elem, len) => write!(f, "[{}; {}]", elem, len),
+            Ty::Struct(name) => write!(f, "{}", name),
         }
     }
 }
 
-fn resolve_type(ty: &ast::TypeName) -> Result<Ty, Diagnostic> {
+fn resolve_type(
+    ty: &ast::TypeName,
+    struct_names: &std::collections::HashSet<String>,
+) -> Result<Ty, Diagnostic> {
     match ty {
         ast::TypeName::Named(name, span) => match name.as_str() {
             "int" => Ok(Ty::Int),
             "bool" => Ok(Ty::Bool),
+            other if struct_names.contains(other) => Ok(Ty::Struct(other.to_string())),
             other => Err(Diagnostic::error(
                 format!("unknown type '{}'", other),
                 *span,
             )),
         },
-        ast::TypeName::Pointer(inner, _) => Ok(Ty::Pointer(Box::new(resolve_type(inner)?))),
-        ast::TypeName::Array(elem, len, _) => Ok(Ty::Array(Box::new(resolve_type(elem)?), *len)),
+        ast::TypeName::Pointer(inner, _) => {
+            Ok(Ty::Pointer(Box::new(resolve_type(inner, struct_names)?)))
+        }
+        ast::TypeName::Array(elem, len, _) => {
+            Ok(Ty::Array(Box::new(resolve_type(elem, struct_names)?), *len))
+        }
     }
 }
 
-/// Size of a value of this type, in bytes. Everything is word-sized so far
-/// except arrays, which are as big as their element type times their length.
-fn size_of(ty: &Ty) -> usize {
+/// Resolves an expression that denotes an addressable "place" - a plain
+/// local variable, or a chain of field accesses off one - to its absolute
+/// stack offset, type, and whether the underlying variable is `mut`.
+/// Index expressions aren't handled here yet (`arr[i].field` is a
+/// follow-up), so this only covers `name` and `name.a.b.c` chains.
+fn resolve_place(expr: &ast::Expr, ctx: &Ctx<'_>) -> Result<(usize, Ty, bool), Diagnostic> {
+    match expr {
+        ast::Expr::Ident(name, span) => match ctx.symbols.get(name) {
+            Some(Symbol::Local(offset, ty, mutable)) => Ok((*offset, ty.clone(), *mutable)),
+            Some(Symbol::Const(_, _)) => Err(Diagnostic::error(
+                format!(
+                    "'{}' is a compile-time constant with no memory location; use 'let mut' instead",
+                    name
+                ),
+                *span,
+            )),
+            None => Err(Diagnostic::error(
+                format!("undefined name '{}'", name),
+                *span,
+            )),
+        },
+
+        ast::Expr::Field { base, field, span } => {
+            let (base_offset, base_ty, mutable) = resolve_place(base, ctx)?;
+            match base_ty {
+                Ty::Struct(struct_name) => {
+                    let info = &ctx.structs[&struct_name];
+                    let (_, field_ty, field_offset) = info
+                        .fields
+                        .iter()
+                        .find(|(n, _, _)| n == field)
+                        .ok_or_else(|| {
+                            Diagnostic::error(
+                                format!("struct '{}' has no field '{}'", struct_name, field),
+                                *span,
+                            )
+                        })?;
+                    Ok((base_offset + *field_offset, field_ty.clone(), mutable))
+                }
+                other => Err(Diagnostic::error(
+                    format!("cannot access field '{}' on a '{}'", field, other),
+                    *span,
+                )),
+            }
+        }
+
+        other => Err(Diagnostic::error(
+            "only a plain variable or a chain of field accesses is supported here right now",
+            other.span(),
+        )),
+    }
+}
+
+/// Lowers an array or struct literal that's the direct initializer of a
+/// `let`, flattening it into `Store`s at `base_offset + <field/element
+/// offset>`. We have no runtime representation of a whole array/struct
+/// *value* yet - only places (memory locations) for them - so this only
+/// ever runs at the top of a `let`, recursing into nested composites.
+fn lower_composite_literal(
+    expr: &ast::Expr,
+    base_offset: usize,
+    ctx: &Ctx<'_>,
+    body: &mut Vec<CheckedStmt>,
+) -> Result<Ty, Diagnostic> {
+    match expr {
+        ast::Expr::ArrayLit { elements, span } => {
+            let mut checked_elements = Vec::with_capacity(elements.len());
+            let mut elem_ty: Option<Ty> = None;
+            for el in elements {
+                let (checked, ty) = lower_expr(el, ctx)?;
+                match &elem_ty {
+                    None => elem_ty = Some(ty.clone()),
+                    Some(expected) if *expected != ty => {
+                        return Err(Diagnostic::error(
+                            format!(
+                                "array elements must all have the same type - expected '{}', found '{}'",
+                                expected, ty
+                            ),
+                            el.span(),
+                        ));
+                    }
+                    _ => {}
+                }
+                checked_elements.push(checked);
+            }
+            let elem_ty =
+                elem_ty.ok_or_else(|| Diagnostic::error("array literal cannot be empty", *span))?;
+            let len = checked_elements.len() as u32;
+            let elem_size = size_of(&elem_ty, ctx.structs);
+
+            for (i, elem_value) in checked_elements.into_iter().enumerate() {
+                body.push(CheckedStmt::Store {
+                    offset: base_offset + i * elem_size,
+                    value: elem_value,
+                });
+            }
+
+            Ok(Ty::Array(Box::new(elem_ty), len))
+        }
+
+        ast::Expr::StructLit { name, fields, span } => {
+            let info = ctx
+                .structs
+                .get(name)
+                .ok_or_else(|| Diagnostic::error(format!("unknown struct '{}'", name), *span))?;
+
+            let mut remaining: HashMap<&str, &ast::Expr> =
+                fields.iter().map(|(n, v)| (n.as_str(), v)).collect();
+            if remaining.len() != fields.len() {
+                return Err(Diagnostic::error(
+                    format!("duplicate field in struct literal for '{}'", name),
+                    *span,
+                ));
+            }
+
+            for (field_name, field_ty, field_offset) in &info.fields {
+                let value_expr = remaining.remove(field_name.as_str()).ok_or_else(|| {
+                    Diagnostic::error(
+                        format!(
+                            "missing field '{}' in literal for struct '{}'",
+                            field_name, name
+                        ),
+                        *span,
+                    )
+                })?;
+
+                let value_ty =
+                    lower_composite_literal(value_expr, base_offset + *field_offset, ctx, body)?;
+
+                if value_ty != *field_ty {
+                    return Err(Diagnostic::error(
+                        format!(
+                            "field '{}' of struct '{}' expects '{}', found '{}'",
+                            field_name, name, field_ty, value_ty
+                        ),
+                        value_expr.span(),
+                    ));
+                }
+            }
+
+            if let Some((extra_name, extra_expr)) = remaining.into_iter().next() {
+                return Err(Diagnostic::error(
+                    format!("struct '{}' has no field '{}'", name, extra_name),
+                    extra_expr.span(),
+                ));
+            }
+
+            Ok(Ty::Struct(name.clone()))
+        }
+
+        other => {
+            let (value, ty) = lower_expr(other, ctx)?;
+            body.push(CheckedStmt::Store {
+                offset: base_offset,
+                value,
+            });
+            Ok(ty)
+        }
+    }
+}
+
+fn size_of(ty: &Ty, structs: &HashMap<String, StructInfo>) -> usize {
     match ty {
         Ty::Unit => 0,
         Ty::Int | Ty::Bool | Ty::Pointer(_) => 4,
-        Ty::Array(elem, len) => size_of(elem) * (*len as usize),
+        Ty::Array(elem, len) => size_of(elem, structs) * (*len as usize),
+        Ty::Struct(name) => structs.get(name).map(|info| info.size).unwrap_or(0),
     }
+}
+
+/// A struct's field layout: name, type, and byte offset, in declaration
+/// order, plus the struct's total size.
+pub struct StructInfo {
+    pub fields: Vec<(String, Ty, usize)>,
+    pub size: usize,
+}
+
+/// Resolves every struct's field types and computes byte offsets/total
+/// size for each. Struct-typed fields are computed recursively (so nested
+/// structs work), with a cycle check: a struct can't contain itself *by
+/// value*, directly or indirectly (that's infinite size) - only through a
+/// pointer, which is always 4 bytes regardless of what it points to.
+fn build_struct_registry(
+    structs: &[ast::StructDef],
+    struct_names: &std::collections::HashSet<String>,
+) -> Result<HashMap<String, StructInfo>, Diagnostic> {
+    let mut field_types: HashMap<String, Vec<(String, Ty)>> = HashMap::new();
+    let mut spans: HashMap<String, Span> = HashMap::new();
+
+    for s in structs {
+        let mut seen = std::collections::HashSet::new();
+        let mut fields = Vec::with_capacity(s.fields.len());
+        for field in &s.fields {
+            if !seen.insert(field.name.clone()) {
+                return Err(Diagnostic::error(
+                    format!(
+                        "field '{}' is already defined in struct '{}'",
+                        field.name, s.name
+                    ),
+                    field.span,
+                ));
+            }
+            fields.push((field.name.clone(), resolve_type(&field.ty, struct_names)?));
+        }
+        field_types.insert(s.name.clone(), fields);
+        spans.insert(s.name.clone(), s.span);
+    }
+
+    let mut layouts: HashMap<String, StructInfo> = HashMap::new();
+    let mut in_progress = std::collections::HashSet::new();
+    for name in field_types.keys().cloned().collect::<Vec<_>>() {
+        compute_struct_layout(&name, &field_types, &spans, &mut layouts, &mut in_progress)?;
+    }
+
+    Ok(layouts)
+}
+
+fn compute_struct_layout(
+    name: &str,
+    field_types: &HashMap<String, Vec<(String, Ty)>>,
+    spans: &HashMap<String, Span>,
+    layouts: &mut HashMap<String, StructInfo>,
+    in_progress: &mut std::collections::HashSet<String>,
+) -> Result<(), Diagnostic> {
+    if layouts.contains_key(name) {
+        return Ok(());
+    }
+    if !in_progress.insert(name.to_string()) {
+        return Err(Diagnostic::error(
+            format!(
+                "recursive type '{}' has infinite size - try '*{}' (a pointer) instead",
+                name, name
+            ),
+            spans[name],
+        ));
+    }
+
+    let mut offset = 0usize;
+    let mut resolved_fields = Vec::new();
+    for (field_name, field_ty) in &field_types[name] {
+        if let Ty::Struct(inner_name) = field_ty {
+            compute_struct_layout(inner_name, field_types, spans, layouts, in_progress)?;
+        }
+        let field_size = size_of(field_ty, layouts);
+        resolved_fields.push((field_name.clone(), field_ty.clone(), offset));
+        offset += field_size;
+    }
+
+    in_progress.remove(name);
+    layouts.insert(
+        name.to_string(),
+        StructInfo {
+            fields: resolved_fields,
+            size: offset,
+        },
+    );
+    Ok(())
 }
 
 fn logical_op_str(op: ast::LogicalOp) -> &'static str {
@@ -142,6 +401,18 @@ pub enum CheckedStmt {
 }
 
 pub fn check(program: &ast::Program) -> Result<CheckedProgram, Diagnostic> {
+    let mut struct_names = std::collections::HashSet::new();
+    for s in &program.structs {
+        if !struct_names.insert(s.name.clone()) {
+            return Err(Diagnostic::error(
+                format!("struct '{}' is already defined", s.name),
+                s.span,
+            ));
+        }
+    }
+
+    let structs = build_struct_registry(&program.structs, &struct_names)?;
+
     let mut sigs: HashMap<String, FunctionSig> = HashMap::new();
 
     for function in &program.functions {
@@ -174,11 +445,33 @@ pub fn check(program: &ast::Program) -> Result<CheckedProgram, Diagnostic> {
 
         let mut params = Vec::with_capacity(function.params.len());
         for param in &function.params {
-            params.push(resolve_type(&param.ty)?);
+            let ty = resolve_type(&param.ty, &struct_names)?;
+            if matches!(ty, Ty::Array(_, _) | Ty::Struct(_)) {
+                return Err(Diagnostic::error(
+                    format!(
+                        "'{}' can't be a parameter type yet - arrays and structs aren't supported as parameters or return values; pass a pointer instead",
+                        ty
+                    ),
+                    param.span,
+                ));
+            }
+            params.push(ty);
         }
 
         let return_type = match &function.return_type {
-            Some(ty) => resolve_type(ty)?,
+            Some(ty_name) => {
+                let ty = resolve_type(ty_name, &struct_names)?;
+                if matches!(ty, Ty::Array(_, _) | Ty::Struct(_)) {
+                    return Err(Diagnostic::error(
+                        format!(
+                            "'{}' can't be a return type yet - arrays and structs aren't supported as parameters or return values; return a pointer instead",
+                            ty
+                        ),
+                        ty_name.span(),
+                    ));
+                }
+                ty
+            }
             None => Ty::Unit,
         };
 
@@ -200,7 +493,7 @@ pub fn check(program: &ast::Program) -> Result<CheckedProgram, Diagnostic> {
 
     let mut functions = Vec::new();
     for function in &program.functions {
-        functions.push(check_function(function, &sigs)?);
+        functions.push(check_function(function, &sigs, &structs)?);
     }
 
     Ok(CheckedProgram { functions })
@@ -220,6 +513,7 @@ struct Ctx<'a> {
     symbols: HashMap<String, Symbol>,
     frame_size: usize,
     sigs: &'a HashMap<String, FunctionSig>,
+    structs: &'a HashMap<String, StructInfo>,
     return_type: Ty,
     is_entry: bool,
 }
@@ -227,6 +521,7 @@ struct Ctx<'a> {
 fn check_function(
     function: &ast::FunctionDef,
     sigs: &HashMap<String, FunctionSig>,
+    structs: &HashMap<String, StructInfo>,
 ) -> Result<CheckedFunction, Diagnostic> {
     let sig = &sigs[&function.name];
 
@@ -234,6 +529,7 @@ fn check_function(
         symbols: HashMap::new(),
         frame_size: 0,
         sigs,
+        structs,
         return_type: sig.return_type.clone(),
         is_entry: function.name == "main",
     };
@@ -290,54 +586,16 @@ fn check_block(stmts: &[ast::Stmt], ctx: &mut Ctx<'_>) -> Result<Vec<CheckedStmt
                     ));
                 }
 
-                if let ast::Expr::ArrayLit { elements, .. } = value {
-                    if !*mutable {
-                        return Err(Diagnostic::error(
-                            format!(
-                                "'{}' must be declared 'let mut' - arrays always live in real memory",
-                                name
-                            ),
-                            *span,
-                        ));
-                    }
+                if matches!(
+                    value,
+                    ast::Expr::ArrayLit { .. } | ast::Expr::StructLit { .. }
+                ) {
+                    let base_offset = ctx.frame_size + 4;
+                    let ty = lower_composite_literal(value, base_offset, ctx, &mut body)?;
+                    ctx.frame_size += size_of(&ty, ctx.structs);
 
-                    let mut checked_elements = Vec::with_capacity(elements.len());
-                    let mut elem_ty: Option<Ty> = None;
-                    for el in elements {
-                        let (checked, ty) = lower_expr(el, ctx)?;
-                        match &elem_ty {
-                            None => elem_ty = Some(ty.clone()),
-                            Some(expected) if *expected != ty => {
-                                return Err(Diagnostic::error(
-                                    format!(
-                                        "array elements must all have the same type - expected '{}', found '{}'",
-                                        expected, ty
-                                    ),
-                                    el.span(),
-                                ));
-                            }
-                            _ => {}
-                        }
-                        checked_elements.push(checked);
-                    }
-                    let elem_ty = elem_ty.expect("parser rejects empty array literals");
-                    let len = checked_elements.len() as u32;
-                    let elem_size = size_of(&elem_ty);
-
-                    let base_offset = ctx.frame_size + elem_size;
-                    ctx.frame_size += elem_size * len as usize;
-
-                    for (i, elem_value) in checked_elements.into_iter().enumerate() {
-                        body.push(CheckedStmt::Store {
-                            offset: base_offset + i * elem_size,
-                            value: elem_value,
-                        });
-                    }
-
-                    ctx.symbols.insert(
-                        name.clone(),
-                        Symbol::Local(base_offset, Ty::Array(Box::new(elem_ty), len), true),
-                    );
+                    ctx.symbols
+                        .insert(name.clone(), Symbol::Local(base_offset, ty, *mutable));
                     continue;
                 }
 
@@ -437,41 +695,15 @@ fn check_block(stmts: &[ast::Stmt], ctx: &mut Ctx<'_>) -> Result<Vec<CheckedStmt
                 }
 
                 ast::AssignTarget::Index { base, index } => {
-                    let name = match base {
-                        ast::Expr::Ident(name, _) => name,
+                    let (base_offset, base_ty, is_mutable) = resolve_place(base, ctx)?;
+                    let elem_ty = match base_ty {
+                        Ty::Array(elem_ty, _) => *elem_ty,
                         other => {
                             return Err(Diagnostic::error(
-                                "only a plain array variable can be indexed for assignment right now (e.g. 'arr[i] = v;')",
-                                other.span(),
-                            ));
-                        }
-                    };
-
-                    let (base_offset, elem_ty, is_mutable) = match ctx.symbols.get(name) {
-                        Some(Symbol::Local(offset, Ty::Array(elem_ty, _), mutable)) => {
-                            (*offset, (**elem_ty).clone(), *mutable)
-                        }
-                        Some(Symbol::Local(_, other_ty, _)) => {
-                            return Err(Diagnostic::error(
                                 format!(
-                                    "cannot index into '{}' - it has type '{}', not an array",
-                                    name, other_ty
+                                    "cannot index into a '{}' - only arrays can be indexed",
+                                    other
                                 ),
-                                *span,
-                            ));
-                        }
-                        Some(Symbol::Const(_, _)) => {
-                            return Err(Diagnostic::error(
-                                format!(
-                                    "cannot index into '{}' - it is a constant, not an array",
-                                    name
-                                ),
-                                *span,
-                            ));
-                        }
-                        None => {
-                            return Err(Diagnostic::error(
-                                format!("undefined name '{}'", name),
                                 *span,
                             ));
                         }
@@ -479,10 +711,7 @@ fn check_block(stmts: &[ast::Stmt], ctx: &mut Ctx<'_>) -> Result<Vec<CheckedStmt
 
                     if !is_mutable {
                         return Err(Diagnostic::error(
-                            format!(
-                                "cannot assign to an element of '{}' - it is not declared 'mut'",
-                                name
-                            ),
+                            "cannot assign to an array element - the array is not declared 'mut'",
                             *span,
                         ));
                     }
@@ -510,9 +739,59 @@ fn check_block(stmts: &[ast::Stmt], ctx: &mut Ctx<'_>) -> Result<Vec<CheckedStmt
                     body.push(CheckedStmt::StoreIndexed {
                         base_offset,
                         index: checked_index,
-                        elem_size: size_of(&elem_ty),
+                        elem_size: size_of(&elem_ty, ctx.structs),
                         value: checked_value,
                     });
+                }
+
+                ast::AssignTarget::Field { base, field } => {
+                    let (base_offset, base_ty, mutable) = resolve_place(base, ctx)?;
+                    let struct_name = match base_ty {
+                        Ty::Struct(name) => name,
+                        other => {
+                            return Err(Diagnostic::error(
+                                format!("cannot access field '{}' on a '{}'", field, other),
+                                *span,
+                            ));
+                        }
+                    };
+
+                    if !mutable {
+                        return Err(Diagnostic::error(
+                            format!(
+                                "cannot assign to a field of '{}' - it is not declared 'mut'",
+                                struct_name
+                            ),
+                            *span,
+                        ));
+                    }
+
+                    let info = &ctx.structs[&struct_name];
+                    let (_, field_ty, field_offset) = info
+                        .fields
+                        .iter()
+                        .find(|(n, _, _)| n == field)
+                        .ok_or_else(|| {
+                            Diagnostic::error(
+                                format!("struct '{}' has no field '{}'", struct_name, field),
+                                *span,
+                            )
+                        })?;
+                    let offset = base_offset + *field_offset;
+                    let field_ty = field_ty.clone();
+
+                    let (value, value_ty) = lower_expr(value, ctx)?;
+                    if value_ty != field_ty {
+                        return Err(Diagnostic::error(
+                            format!(
+                                "cannot assign a '{}' to field '{}', which is a '{}'",
+                                value_ty, field, field_ty
+                            ),
+                            *span,
+                        ));
+                    }
+
+                    body.push(CheckedStmt::Store { offset, value });
                 }
             },
 
@@ -625,7 +904,18 @@ fn lower_expr(expr: &ast::Expr, ctx: &Ctx<'_>) -> Result<(CheckedExpr, Ty), Diag
 
         ast::Expr::Ident(name, span) => match ctx.symbols.get(name) {
             Some(Symbol::Const(value, ty)) => Ok((CheckedExpr::Const(*value), ty.clone())),
-            Some(Symbol::Local(offset, ty, _)) => Ok((CheckedExpr::Local(*offset), ty.clone())),
+            Some(Symbol::Local(offset, ty, _)) => {
+                if matches!(ty, Ty::Array(_, _) | Ty::Struct(_)) {
+                    return Err(Diagnostic::error(
+                        format!(
+                            "cannot use the whole '{}' value of '{}' directly yet - access an individual field or element instead",
+                            ty, name
+                        ),
+                        *span,
+                    ));
+                }
+                Ok((CheckedExpr::Local(*offset), ty.clone()))
+            }
             None => Err(Diagnostic::error(
                 format!("undefined name '{}'", name),
                 *span,
@@ -889,47 +1179,37 @@ fn lower_expr(expr: &ast::Expr, ctx: &Ctx<'_>) -> Result<(CheckedExpr, Ty), Diag
             )),
         },
 
-        ast::Expr::ArrayLit { span, .. } => Err(Diagnostic::error(
-            "array literals are only allowed as the direct initializer of a 'let' binding right now",
-            *span,
-        )),
+        ast::Expr::ArrayLit { span, .. } | ast::Expr::StructLit { span, .. } => {
+            Err(Diagnostic::error(
+                "array/struct literals are only allowed as the direct initializer of a 'let' binding right now",
+                *span,
+            ))
+        }
+
+        ast::Expr::Field { .. } => {
+            let (offset, ty, _mutable) = resolve_place(expr, ctx)?;
+            if matches!(ty, Ty::Array(_, _) | Ty::Struct(_)) {
+                return Err(Diagnostic::error(
+                    format!(
+                        "cannot use the whole '{}' value directly yet - access an individual field or element instead",
+                        ty
+                    ),
+                    expr.span(),
+                ));
+            }
+            Ok((CheckedExpr::Local(offset), ty))
+        }
 
         ast::Expr::Index { base, index, span } => {
-            let name = match base.as_ref() {
-                ast::Expr::Ident(name, _) => name,
+            let (base_offset, base_ty, _mutable) = resolve_place(base, ctx)?;
+            let elem_ty = match base_ty {
+                Ty::Array(elem_ty, _) => *elem_ty,
                 other => {
                     return Err(Diagnostic::error(
-                        "only a plain array variable can be indexed right now (e.g. 'arr[i]')",
-                        other.span(),
-                    ));
-                }
-            };
-
-            let (base_offset, elem_ty) = match ctx.symbols.get(name) {
-                Some(Symbol::Local(offset, Ty::Array(elem_ty, _), _)) => {
-                    (*offset, (**elem_ty).clone())
-                }
-                Some(Symbol::Local(_, other_ty, _)) => {
-                    return Err(Diagnostic::error(
                         format!(
-                            "cannot index into '{}' - it has type '{}', not an array",
-                            name, other_ty
+                            "cannot index into a '{}' - only arrays can be indexed",
+                            other
                         ),
-                        *span,
-                    ));
-                }
-                Some(Symbol::Const(_, _)) => {
-                    return Err(Diagnostic::error(
-                        format!(
-                            "cannot index into '{}' - it is a constant, not an array",
-                            name
-                        ),
-                        *span,
-                    ));
-                }
-                None => {
-                    return Err(Diagnostic::error(
-                        format!("undefined name '{}'", name),
                         *span,
                     ));
                 }
@@ -944,7 +1224,7 @@ fn lower_expr(expr: &ast::Expr, ctx: &Ctx<'_>) -> Result<(CheckedExpr, Ty), Diag
                 ));
             }
 
-            let elem_size = size_of(&elem_ty);
+            let elem_size = size_of(&elem_ty, ctx.structs);
             Ok((
                 CheckedExpr::Index {
                     base_offset,


### PR DESCRIPTION
## Summary

Adds support for `struct`s:
- `struct Name { field: Type, ... }` declares a struct, forward-declared like functions (order-independent).
- Struct literals (`Name { field: value, ... }`) work like array literals - only as a `let`/`let mut` initializer, fields in any order but all required.
- Field access (`s.field`, chainable as `s.a.b.c`) works for reads and, on a `mut` struct, writes, and composes with arrays (`s.arr[i]`).
- A struct can't contain itself by value (infinite size) - only through a pointer (`*Name`), same as recursive data structures in C. Locals only, not function parameters or return values.

## Related issue(s)

Closes #133

## Area

Lexer, Ast, Parser, Semantics

## Checklist

- [x] `cargo build` succeeds
- [x] Added/updated an example in `examples/` if this changes or adds language surface
- [x] Updated `README.md` (roadmap/language surface section) if applicable
- [x] This is **not** a breaking change to existing `.cfy` syntax/behavior, or it's labeled `breaking-change` and explained below

## Notes for reviewers

<!-- Anything that needs extra attention, open questions, follow-up work, etc. -->
