### PR TITLE
feat(#142): basic ir implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Set up Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Check formatting
+        run: nix develop --command cargo fmt --check
+
+      - name: Clippy
+        run: nix develop --command cargo clippy -- -D warnings
+
+      - name: Build
+        run: nix develop --command cargo build
+
+      - name: Run example test suite
+        run: nix develop --command util/test_examples.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ ARM32 (`arm-none-eabi` or similar) assembler/linker and `qemu-arm` on your `PATH
 3. If you add or change language surface (new syntax, new semantics), add a short
    example under [`examples/`](./examples) and update the "Current language surface"
    section of `README.md`.
-4. Make sure `cargo build` succeeds before opening a PR.
+4. Make sure `cargo build` succeeds and `util/test_examples.sh` passes before opening a PR (CI checks both).
 5. Fill out the PR template, including which `area:` the change belongs to.
 
 ## Reporting bugs

--- a/src/codegen/arm32.rs
+++ b/src/codegen/arm32.rs
@@ -1,18 +1,16 @@
 //! ARM32 (armv7, EABI) backend.
 //!
-//! Emits GNU-assembler syntax targeting `arm-linux-gnueabihf`. Syscalls use
-//! the standard EABI convention: syscall number in `r7`, up to 6 arguments
-//! in `r0`-`r5`, trapped with `svc #0`. Function calls follow AAPCS: up to
-//! 4 integer arguments in `r0`-`r3`, return value in `r0`.
-//!
-//! Runtime expressions are evaluated with a simple stack machine: every
-//! `emit_expr` call leaves its result on top of the stack. This is not
-//! optimal codegen (a real register allocator comes later, once there's an
-//! IR), but it's simple and obviously correct.
+//! Emits GNU-assembler syntax targeting `arm-linux-gnueabihf`. Consumes the
+//! flat IR (`crate::ir`) rather than the checked expression tree directly.
+//! Every virtual register gets its own dedicated stack spill slot for now -
+//! this is intentionally "dumb" (equivalent in spirit to the old push/pop
+//! stack machine), just restructured around the new IR. Real register
+//! allocation (mapping hot virtual registers to `r4`-`r11` instead of
+//! memory) is a follow-up step.
 
 use crate::ast;
 use crate::codegen::Backend;
-use crate::sema::{CheckedExpr, CheckedFunction, CheckedProgram, CheckedStmt};
+use crate::ir::{self, VReg};
 
 pub struct Arm32Backend;
 
@@ -21,11 +19,11 @@ impl Backend for Arm32Backend {
         "arm32"
     }
 
-    fn emit(&self, program: &CheckedProgram) -> String {
+    fn emit(&self, program: &ir::Program) -> String {
         let mut emitter = Emitter {
             out: String::new(),
-            label_counter: 0,
             return_label: None,
+            vreg_base: 0,
         };
 
         emitter.out.push_str(".global _start\n");
@@ -46,30 +44,41 @@ fn label_for(name: &str) -> &str {
     if name == "main" { "_start" } else { name }
 }
 
-/// Bundles the output buffer with a monotonic counter for generating
-/// unique, deterministic labels (`.Lif_end0`, `.Lwhile_start1`, ...), plus
-/// the current function's epilogue label for `return` to jump to.
 struct Emitter {
     out: String,
-    label_counter: usize,
     return_label: Option<String>,
+    /// Byte offset (from `fp`) where this function's local-variable frame
+    /// ends and its virtual-register spill slots begin.
+    vreg_base: usize,
 }
 
 impl Emitter {
-    fn new_label(&mut self, prefix: &str) -> String {
-        let label = format!(".L{}{}", prefix, self.label_counter);
-        self.label_counter += 1;
-        label
+    fn vreg_offset(&self, v: VReg) -> usize {
+        self.vreg_base + 4 * (v.0 as usize + 1)
     }
 
-    fn emit_function(&mut self, function: &CheckedFunction) {
-        let is_entry = function.name == "main";
+    fn load(&mut self, reg: &str, v: VReg) {
+        let offset = self.vreg_offset(v);
+        self.out
+            .push_str(&format!("\tldr {}, [fp, #-{}]\n", reg, offset));
+    }
+
+    fn store(&mut self, reg: &str, v: VReg) {
+        let offset = self.vreg_offset(v);
+        self.out
+            .push_str(&format!("\tstr {}, [fp, #-{}]\n", reg, offset));
+    }
+
+    fn emit_function(&mut self, function: &ir::Function) {
+        self.vreg_base = function.frame_size;
+        let total_frame = function.frame_size + 4 * function.vreg_count as usize;
+
         self.out
             .push_str(&format!("{}:\n", label_for(&function.name)));
 
-        if is_entry {
-            if function.frame_size > 0 {
-                let aligned = (function.frame_size + 7) & !7;
+        if function.is_entry {
+            if total_frame > 0 {
+                let aligned = (total_frame + 7) & !7;
                 self.out.push_str("\tmov fp, sp\n");
                 self.out.push_str(&format!("\tsub sp, sp, #{}\n", aligned));
             }
@@ -77,8 +86,8 @@ impl Emitter {
         } else {
             self.out.push_str("\tpush {fp, lr}\n");
             self.out.push_str("\tmov fp, sp\n");
-            if function.frame_size > 0 {
-                let aligned = (function.frame_size + 7) & !7;
+            if total_frame > 0 {
+                let aligned = (total_frame + 7) & !7;
                 self.out.push_str(&format!("\tsub sp, sp, #{}\n", aligned));
             }
             self.return_label = Some(format!(".Lret_{}", function.name));
@@ -90,8 +99,8 @@ impl Emitter {
                 .push_str(&format!("\tstr {}, [fp, #-{}]\n", reg, offset));
         }
 
-        for stmt in &function.body {
-            self.emit_stmt(stmt);
+        for instr in &function.body {
+            self.emit_instr(instr);
         }
 
         if let Some(label) = self.return_label.clone() {
@@ -102,142 +111,31 @@ impl Emitter {
         }
     }
 
-    fn emit_stmt(&mut self, stmt: &CheckedStmt) {
-        match stmt {
-            CheckedStmt::Store { offset, value } => {
-                self.emit_expr(value);
-                self.out.push_str("\tpop {r0}\n");
-                self.out
-                    .push_str(&format!("\tstr r0, [fp, #-{}]\n", offset));
-            }
-
-            CheckedStmt::Expr(value) => {
-                self.emit_expr(value);
-                self.out.push_str("\tpop {r0}\n"); // discard the result, we only wanted the side effect
-            }
-
-            CheckedStmt::If {
-                cond,
-                then_body,
-                else_body,
-            } => {
-                self.emit_expr(cond);
-                self.out.push_str("\tpop {r0}\n");
-                self.out.push_str("\tcmp r0, #0\n");
-
-                let end_label = self.new_label("if_end");
-
-                if let Some(else_body) = else_body {
-                    let else_label = self.new_label("if_else");
-                    self.out.push_str(&format!("\tbeq {}\n", else_label));
-                    for stmt in then_body {
-                        self.emit_stmt(stmt);
-                    }
-                    self.out.push_str(&format!("\tb {}\n", end_label));
-                    self.out.push_str(&format!("{}:\n", else_label));
-                    for stmt in else_body {
-                        self.emit_stmt(stmt);
-                    }
-                } else {
-                    self.out.push_str(&format!("\tbeq {}\n", end_label));
-                    for stmt in then_body {
-                        self.emit_stmt(stmt);
-                    }
-                }
-
-                self.out.push_str(&format!("{}:\n", end_label));
-            }
-
-            CheckedStmt::While { cond, body } => {
-                let start_label = self.new_label("while_start");
-                let end_label = self.new_label("while_end");
-
-                self.out.push_str(&format!("{}:\n", start_label));
-                self.emit_expr(cond);
-                self.out.push_str("\tpop {r0}\n");
-                self.out.push_str("\tcmp r0, #0\n");
-                self.out.push_str(&format!("\tbeq {}\n", end_label));
-
-                for stmt in body {
-                    self.emit_stmt(stmt);
-                }
-
-                self.out.push_str(&format!("\tb {}\n", start_label));
-                self.out.push_str(&format!("{}:\n", end_label));
-            }
-
-            CheckedStmt::Return(value) => {
-                if let Some(value) = value {
-                    self.emit_expr(value);
-                    self.out.push_str("\tpop {r0}\n");
-                }
-                let label = self
-                    .return_label
-                    .clone()
-                    .expect("'return' should only appear inside a function body");
-                self.out.push_str(&format!("\tb {}\n", label));
-            }
-
-            CheckedStmt::StoreThroughPointer { address, value } => {
-                self.emit_expr(address);
-                self.emit_expr(value);
-                self.out.push_str("\tpop {r1}\n"); // value (pushed last, popped first)
-                self.out.push_str("\tpop {r0}\n"); // address
-                self.out.push_str("\tstr r1, [r0]\n");
-            }
-
-            CheckedStmt::StoreIndexed {
-                base_offset,
-                index,
-                elem_size,
-                value,
-            } => {
-                self.emit_expr(index);
-                self.emit_expr(value);
-                self.out.push_str("\tpop {r3}\n"); // value (pushed last, popped first)
-                self.out.push_str("\tpop {r1}\n"); // index
-                self.out.push_str(&format!("\tmov r2, #{}\n", elem_size));
-                self.out.push_str("\tmul r1, r2, r1\n"); // r1 = index * elem_size
-                self.out
-                    .push_str(&format!("\tsub r0, fp, #{}\n", base_offset));
-                self.out.push_str("\tsub r0, r0, r1\n"); // r0 = address of arr[index]
-                self.out.push_str("\tstr r3, [r0]\n");
-            }
-        }
-    }
-
-    /// Evaluates `expr`, leaving the result on top of the stack.
-    fn emit_expr(&mut self, expr: &CheckedExpr) {
-        match expr {
-            CheckedExpr::Const(value) => {
+    fn emit_instr(&mut self, instr: &ir::Instr) {
+        match instr {
+            ir::Instr::Const { dst, value } => {
                 self.out.push_str(&format!("\tldr r0, ={}\n", value));
-                self.out.push_str("\tpush {r0}\n");
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Local(offset) => {
-                self.out
-                    .push_str(&format!("\tldr r0, [fp, #-{}]\n", offset));
-                self.out.push_str("\tpush {r0}\n");
+            ir::Instr::Copy { dst, src } => {
+                self.load("r0", *src);
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Unary { op, operand } => {
-                self.emit_expr(operand);
-                self.out.push_str("\tpop {r0}\n");
+            ir::Instr::Unary { dst, op, src } => {
+                self.load("r0", *src);
                 match op {
                     ast::UnaryOp::Neg => self.out.push_str("\trsb r0, r0, #0\n"),
                     ast::UnaryOp::Not => self.out.push_str("\teor r0, r0, #1\n"),
-                    ast::UnaryOp::Deref => {
-                        unreachable!("Deref is lowered to CheckedExpr::Deref, not Unary")
-                    }
+                    ast::UnaryOp::Deref => unreachable!("Deref lowers to ir::Instr::Load"),
                 }
-                self.out.push_str("\tpush {r0}\n");
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Binary { op, lhs, rhs } => {
-                self.emit_expr(lhs);
-                self.emit_expr(rhs);
-                self.out.push_str("\tpop {r1}\n");
-                self.out.push_str("\tpop {r0}\n");
+            ir::Instr::Binary { dst, op, lhs, rhs } => {
+                self.load("r0", *lhs);
+                self.load("r1", *rhs);
                 match op {
                     ast::BinOp::Add => self.out.push_str("\tadd r0, r0, r1\n"),
                     ast::BinOp::Sub => self.out.push_str("\tsub r0, r0, r1\n"),
@@ -246,14 +144,12 @@ impl Emitter {
                         unreachable!("division/remainder should have been rejected in sema")
                     }
                 }
-                self.out.push_str("\tpush {r0}\n");
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Compare { op, lhs, rhs } => {
-                self.emit_expr(lhs);
-                self.emit_expr(rhs);
-                self.out.push_str("\tpop {r1}\n");
-                self.out.push_str("\tpop {r0}\n");
+            ir::Instr::Compare { dst, op, lhs, rhs } => {
+                self.load("r0", *lhs);
+                self.load("r1", *rhs);
                 self.out.push_str("\tcmp r0, r1\n");
                 self.out.push_str("\tmov r0, #0\n");
                 let cond = match op {
@@ -265,102 +161,120 @@ impl Emitter {
                     ast::CompareOp::Ge => "movge",
                 };
                 self.out.push_str(&format!("\t{} r0, #1\n", cond));
-                self.out.push_str("\tpush {r0}\n");
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Logical { op, lhs, rhs } => match op {
-                ast::LogicalOp::And => {
-                    let false_label = self.new_label("and_false");
-                    let end_label = self.new_label("and_end");
-
-                    self.emit_expr(lhs);
-                    self.out.push_str("\tpop {r0}\n");
-                    self.out.push_str("\tcmp r0, #0\n");
-                    self.out.push_str(&format!("\tbeq {}\n", false_label));
-
-                    self.emit_expr(rhs);
-                    self.out.push_str("\tpop {r0}\n");
-                    self.out.push_str(&format!("\tb {}\n", end_label));
-
-                    self.out.push_str(&format!("{}:\n", false_label));
-                    self.out.push_str("\tmov r0, #0\n");
-
-                    self.out.push_str(&format!("{}:\n", end_label));
-                    self.out.push_str("\tpush {r0}\n");
-                }
-                ast::LogicalOp::Or => {
-                    let true_label = self.new_label("or_true");
-                    let end_label = self.new_label("or_end");
-
-                    self.emit_expr(lhs);
-                    self.out.push_str("\tpop {r0}\n");
-                    self.out.push_str("\tcmp r0, #0\n");
-                    self.out.push_str(&format!("\tbne {}\n", true_label));
-
-                    self.emit_expr(rhs);
-                    self.out.push_str("\tpop {r0}\n");
-                    self.out.push_str(&format!("\tb {}\n", end_label));
-
-                    self.out.push_str(&format!("{}:\n", true_label));
-                    self.out.push_str("\tmov r0, #1\n");
-
-                    self.out.push_str(&format!("{}:\n", end_label));
-                    self.out.push_str("\tpush {r0}\n");
-                }
-            },
-
-            CheckedExpr::Syscall { args } => {
-                for arg in args.iter() {
-                    self.emit_expr(arg);
-                }
-                self.out.push_str("\tpop {r5}\n");
-                self.out.push_str("\tpop {r4}\n");
-                self.out.push_str("\tpop {r3}\n");
-                self.out.push_str("\tpop {r2}\n");
-                self.out.push_str("\tpop {r1}\n");
-                self.out.push_str("\tpop {r0}\n");
-                self.out.push_str("\tpop {r7}\n");
-                self.out.push_str("\tsvc #0\n");
-                self.out.push_str("\tpush {r0}\n");
+            ir::Instr::LoadLocal { dst, offset } => {
+                self.out
+                    .push_str(&format!("\tldr r0, [fp, #-{}]\n", offset));
+                self.store("r0", *dst);
             }
 
-            CheckedExpr::Call { name, args } => {
-                for arg in args {
-                    self.emit_expr(arg);
-                }
-                for i in (0..args.len()).rev() {
-                    self.out.push_str(&format!("\tpop {{r{}}}\n", i));
-                }
-                self.out.push_str(&format!("\tbl {}\n", label_for(name)));
-                self.out.push_str("\tpush {r0}\n");
+            ir::Instr::StoreLocal { offset, src } => {
+                self.load("r0", *src);
+                self.out
+                    .push_str(&format!("\tstr r0, [fp, #-{}]\n", offset));
             }
 
-            CheckedExpr::AddressOf(offset) => {
-                self.out.push_str(&format!("\tsub r0, fp, #{}\n", offset));
-                self.out.push_str("\tpush {r0}\n");
-            }
-
-            CheckedExpr::Deref(inner) => {
-                self.emit_expr(inner);
-                self.out.push_str("\tpop {r0}\n");
-                self.out.push_str("\tldr r0, [r0]\n");
-                self.out.push_str("\tpush {r0}\n");
-            }
-
-            CheckedExpr::Index {
+            ir::Instr::LoadIndexed {
+                dst,
                 base_offset,
                 index,
                 elem_size,
             } => {
-                self.emit_expr(index);
-                self.out.push_str("\tpop {r1}\n"); // index
+                self.load("r1", *index);
                 self.out.push_str(&format!("\tmov r2, #{}\n", elem_size));
-                self.out.push_str("\tmul r1, r2, r1\n"); // r1 = index * elem_size
+                self.out.push_str("\tmul r1, r2, r1\n");
                 self.out
                     .push_str(&format!("\tsub r0, fp, #{}\n", base_offset));
-                self.out.push_str("\tsub r0, r0, r1\n"); // r0 = address of arr[index]
+                self.out.push_str("\tsub r0, r0, r1\n");
                 self.out.push_str("\tldr r0, [r0]\n");
-                self.out.push_str("\tpush {r0}\n");
+                self.store("r0", *dst);
+            }
+
+            ir::Instr::StoreIndexed {
+                base_offset,
+                index,
+                elem_size,
+                src,
+            } => {
+                self.load("r1", *index);
+                self.load("r3", *src);
+                self.out.push_str(&format!("\tmov r2, #{}\n", elem_size));
+                self.out.push_str("\tmul r1, r2, r1\n");
+                self.out
+                    .push_str(&format!("\tsub r0, fp, #{}\n", base_offset));
+                self.out.push_str("\tsub r0, r0, r1\n");
+                self.out.push_str("\tstr r3, [r0]\n");
+            }
+
+            ir::Instr::AddressOf { dst, offset } => {
+                self.out.push_str(&format!("\tsub r0, fp, #{}\n", offset));
+                self.store("r0", *dst);
+            }
+
+            ir::Instr::Load { dst, addr } => {
+                self.load("r0", *addr);
+                self.out.push_str("\tldr r0, [r0]\n");
+                self.store("r0", *dst);
+            }
+
+            ir::Instr::Store { addr, src } => {
+                self.load("r0", *addr);
+                self.load("r1", *src);
+                self.out.push_str("\tstr r1, [r0]\n");
+            }
+
+            ir::Instr::Syscall { dst, args } => {
+                self.load("r7", args[0]);
+                let regs = ["r0", "r1", "r2", "r3", "r4", "r5"];
+                for (reg, arg) in regs.iter().zip(&args[1..]) {
+                    self.load(reg, *arg);
+                }
+                self.out.push_str("\tsvc #0\n");
+                self.store("r0", *dst);
+            }
+
+            ir::Instr::Call { dst, name, args } => {
+                let regs = ["r0", "r1", "r2", "r3"];
+                for (reg, arg) in regs.iter().zip(args) {
+                    self.load(reg, *arg);
+                }
+                self.out.push_str(&format!("\tbl {}\n", label_for(name)));
+                if let Some(dst) = dst {
+                    self.store("r0", *dst);
+                }
+            }
+
+            ir::Instr::Label(label) => {
+                self.out.push_str(&format!("{}:\n", label));
+            }
+
+            ir::Instr::Jump(label) => {
+                self.out.push_str(&format!("\tb {}\n", label));
+            }
+
+            ir::Instr::JumpIfZero { cond, label } => {
+                self.load("r0", *cond);
+                self.out.push_str("\tcmp r0, #0\n");
+                self.out.push_str(&format!("\tbeq {}\n", label));
+            }
+
+            ir::Instr::JumpIfNotZero { cond, label } => {
+                self.load("r0", *cond);
+                self.out.push_str("\tcmp r0, #0\n");
+                self.out.push_str(&format!("\tbne {}\n", label));
+            }
+
+            ir::Instr::Return(value) => {
+                if let Some(v) = value {
+                    self.load("r0", *v);
+                }
+                let label = self
+                    .return_label
+                    .clone()
+                    .expect("'return' should only appear inside a function body");
+                self.out.push_str(&format!("\tb {}\n", label));
             }
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,8 +1,8 @@
-use crate::sema::CheckedProgram;
+use crate::ir::Program;
 
 pub mod arm32;
 
 pub trait Backend {
     fn name(&self) -> &'static str;
-    fn emit(&self, program: &CheckedProgram) -> String;
+    fn emit(&self, program: &Program) -> String;
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,12 @@ pub struct TargetSection {
 
 impl Default for ProjectConfig {
     fn default() -> Self {
-        Self { target: TargetSection { arch: "arm32".to_string(), output: None } }
+        Self {
+            target: TargetSection {
+                arch: "arm32".to_string(),
+                output: None,
+            },
+        }
     }
 }
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -30,7 +30,10 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     pub fn error(message: impl Into<String>, span: Span) -> Self {
-        Self { message: message.into(), span }
+        Self {
+            message: message.into(),
+            span,
+        }
     }
 
     /// Render this diagnostic as a human-readable, pointer-annotated message,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,0 +1,407 @@
+use crate::{
+    ast,
+    sema::{CheckedExpr, CheckedFunction, CheckedProgram, CheckedStmt},
+};
+
+/// A virtual register: one SSA-like "slot" holding a single value. There's
+/// an unlimited supply of these during lowering; a later register
+/// allocator maps them down to the handful of real ARM registers.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VReg(pub u32);
+
+pub enum Instr {
+    Const {
+        dst: VReg,
+        value: i64,
+    },
+    Copy {
+        dst: VReg,
+        src: VReg,
+    },
+    Unary {
+        dst: VReg,
+        op: ast::UnaryOp,
+        src: VReg,
+    },
+    Binary {
+        dst: VReg,
+        op: ast::BinOp,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Compare {
+        dst: VReg,
+        op: ast::CompareOp,
+        lhs: VReg,
+        rhs: VReg,
+    },
+
+    LoadLocal {
+        dst: VReg,
+        offset: usize,
+    },
+    StoreLocal {
+        offset: usize,
+        src: VReg,
+    },
+    LoadIndexed {
+        dst: VReg,
+        base_offset: usize,
+        index: VReg,
+        elem_size: usize,
+    },
+    StoreIndexed {
+        base_offset: usize,
+        index: VReg,
+        elem_size: usize,
+        src: VReg,
+    },
+    AddressOf {
+        dst: VReg,
+        offset: usize,
+    },
+    Load {
+        dst: VReg,
+        addr: VReg,
+    }, // *p (read)
+    Store {
+        addr: VReg,
+        src: VReg,
+    }, // *p = v (write)
+
+    Syscall {
+        dst: VReg,
+        args: [VReg; 7],
+    },
+    Call {
+        dst: Option<VReg>,
+        name: String,
+        args: Vec<VReg>,
+    },
+
+    Label(String),
+    Jump(String),
+    JumpIfZero {
+        cond: VReg,
+        label: String,
+    },
+    JumpIfNotZero {
+        cond: VReg,
+        label: String,
+    },
+    Return(Option<VReg>),
+}
+
+pub struct Function {
+    pub name: String,
+    pub is_entry: bool,
+    pub param_offsets: Vec<usize>,
+    pub frame_size: usize,
+    pub vreg_count: u32,
+    pub body: Vec<Instr>,
+}
+
+pub struct Program {
+    pub functions: Vec<Function>,
+}
+
+struct Lowering {
+    next_vreg: u32,
+    label_counter: usize,
+    body: Vec<Instr>,
+}
+
+impl Lowering {
+    fn new() -> Self {
+        Lowering {
+            next_vreg: 0,
+            label_counter: 0,
+            body: Vec::new(),
+        }
+    }
+
+    fn new_vreg(&mut self) -> VReg {
+        let v = VReg(self.next_vreg);
+        self.next_vreg += 1;
+        v
+    }
+
+    fn new_label(&mut self, prefix: &str) -> String {
+        let label = format!(".L{}{}", prefix, self.label_counter);
+        self.label_counter += 1;
+        label
+    }
+
+    fn emit(&mut self, instr: Instr) {
+        self.body.push(instr);
+    }
+
+    fn lower_stmt(&mut self, stmt: &CheckedStmt) {
+        match stmt {
+            CheckedStmt::Store { offset, value } => {
+                let src = self.lower_expr(value);
+                self.emit(Instr::StoreLocal {
+                    offset: *offset,
+                    src,
+                });
+            }
+
+            CheckedStmt::Expr(value) => {
+                self.lower_expr(value); // side effects only, result discarded
+            }
+
+            CheckedStmt::If {
+                cond,
+                then_body,
+                else_body,
+            } => {
+                let cond_v = self.lower_expr(cond);
+                let end_label = self.new_label("if_end");
+
+                if let Some(else_body) = else_body {
+                    let else_label = self.new_label("if_else");
+                    self.emit(Instr::JumpIfZero {
+                        cond: cond_v,
+                        label: else_label.clone(),
+                    });
+                    for s in then_body {
+                        self.lower_stmt(s);
+                    }
+                    self.emit(Instr::Jump(end_label.clone()));
+                    self.emit(Instr::Label(else_label));
+                    for s in else_body {
+                        self.lower_stmt(s);
+                    }
+                } else {
+                    self.emit(Instr::JumpIfZero {
+                        cond: cond_v,
+                        label: end_label.clone(),
+                    });
+                    for s in then_body {
+                        self.lower_stmt(s);
+                    }
+                }
+
+                self.emit(Instr::Label(end_label));
+            }
+
+            CheckedStmt::While { cond, body } => {
+                let start_label = self.new_label("while_start");
+                let end_label = self.new_label("while_end");
+
+                self.emit(Instr::Label(start_label.clone()));
+                let cond_v = self.lower_expr(cond);
+                self.emit(Instr::JumpIfZero {
+                    cond: cond_v,
+                    label: end_label.clone(),
+                });
+
+                for s in body {
+                    self.lower_stmt(s);
+                }
+
+                self.emit(Instr::Jump(start_label));
+                self.emit(Instr::Label(end_label));
+            }
+
+            CheckedStmt::Return(value) => {
+                let v = value.as_ref().map(|e| self.lower_expr(e));
+                self.emit(Instr::Return(v));
+            }
+
+            CheckedStmt::StoreThroughPointer { address, value } => {
+                let addr = self.lower_expr(address);
+                let src = self.lower_expr(value);
+                self.emit(Instr::Store { addr, src });
+            }
+
+            CheckedStmt::StoreIndexed {
+                base_offset,
+                index,
+                elem_size,
+                value,
+            } => {
+                let index_v = self.lower_expr(index);
+                let src = self.lower_expr(value);
+                self.emit(Instr::StoreIndexed {
+                    base_offset: *base_offset,
+                    index: index_v,
+                    elem_size: *elem_size,
+                    src,
+                });
+            }
+        }
+    }
+
+    fn lower_expr(&mut self, expr: &CheckedExpr) -> VReg {
+        match expr {
+            CheckedExpr::Const(value) => {
+                let dst = self.new_vreg();
+                self.emit(Instr::Const { dst, value: *value });
+                dst
+            }
+
+            CheckedExpr::Local(offset) => {
+                let dst = self.new_vreg();
+                self.emit(Instr::LoadLocal {
+                    dst,
+                    offset: *offset,
+                });
+                dst
+            }
+
+            CheckedExpr::Unary { op, operand } => {
+                let src = self.lower_expr(operand);
+                let dst = self.new_vreg();
+                self.emit(Instr::Unary { dst, op: *op, src });
+                dst
+            }
+
+            CheckedExpr::Binary { op, lhs, rhs } => {
+                let lhs_v = self.lower_expr(lhs);
+                let rhs_v = self.lower_expr(rhs);
+                let dst = self.new_vreg();
+                self.emit(Instr::Binary {
+                    dst,
+                    op: *op,
+                    lhs: lhs_v,
+                    rhs: rhs_v,
+                });
+                dst
+            }
+
+            CheckedExpr::Compare { op, lhs, rhs } => {
+                let lhs_v = self.lower_expr(lhs);
+                let rhs_v = self.lower_expr(rhs);
+                let dst = self.new_vreg();
+                self.emit(Instr::Compare {
+                    dst,
+                    op: *op,
+                    lhs: lhs_v,
+                    rhs: rhs_v,
+                });
+                dst
+            }
+
+            CheckedExpr::Logical { op, lhs, rhs } => match op {
+                ast::LogicalOp::And => {
+                    let dst = self.new_vreg();
+                    let false_label = self.new_label("and_false");
+                    let end_label = self.new_label("and_end");
+
+                    let lhs_v = self.lower_expr(lhs);
+                    self.emit(Instr::JumpIfZero {
+                        cond: lhs_v,
+                        label: false_label.clone(),
+                    });
+
+                    let rhs_v = self.lower_expr(rhs);
+                    self.emit(Instr::Copy { dst, src: rhs_v });
+                    self.emit(Instr::Jump(end_label.clone()));
+
+                    self.emit(Instr::Label(false_label));
+                    self.emit(Instr::Const { dst, value: 0 });
+
+                    self.emit(Instr::Label(end_label));
+                    dst
+                }
+                ast::LogicalOp::Or => {
+                    let dst = self.new_vreg();
+                    let true_label = self.new_label("or_true");
+                    let end_label = self.new_label("or_end");
+
+                    let lhs_v = self.lower_expr(lhs);
+                    self.emit(Instr::JumpIfNotZero {
+                        cond: lhs_v,
+                        label: true_label.clone(),
+                    });
+
+                    let rhs_v = self.lower_expr(rhs);
+                    self.emit(Instr::Copy { dst, src: rhs_v });
+                    self.emit(Instr::Jump(end_label.clone()));
+
+                    self.emit(Instr::Label(true_label));
+                    self.emit(Instr::Const { dst, value: 1 });
+
+                    self.emit(Instr::Label(end_label));
+                    dst
+                }
+            },
+
+            CheckedExpr::Syscall { args } => {
+                let arg_vregs: Vec<VReg> = args.iter().map(|a| self.lower_expr(a)).collect();
+                let args: [VReg; 7] = arg_vregs
+                    .try_into()
+                    .unwrap_or_else(|_| unreachable!("syscall always has exactly 7 args"));
+                let dst = self.new_vreg();
+                self.emit(Instr::Syscall { dst, args });
+                dst
+            }
+
+            CheckedExpr::Call { name, args } => {
+                let arg_vregs: Vec<VReg> = args.iter().map(|a| self.lower_expr(a)).collect();
+                let dst = self.new_vreg();
+                self.emit(Instr::Call {
+                    dst: Some(dst),
+                    name: name.clone(),
+                    args: arg_vregs,
+                });
+                dst
+            }
+
+            CheckedExpr::AddressOf(offset) => {
+                let dst = self.new_vreg();
+                self.emit(Instr::AddressOf {
+                    dst,
+                    offset: *offset,
+                });
+                dst
+            }
+
+            CheckedExpr::Deref(inner) => {
+                let addr = self.lower_expr(inner);
+                let dst = self.new_vreg();
+                self.emit(Instr::Load { dst, addr });
+                dst
+            }
+
+            CheckedExpr::Index {
+                base_offset,
+                index,
+                elem_size,
+            } => {
+                let index_v = self.lower_expr(index);
+                let dst = self.new_vreg();
+                self.emit(Instr::LoadIndexed {
+                    dst,
+                    base_offset: *base_offset,
+                    index: index_v,
+                    elem_size: *elem_size,
+                });
+                dst
+            }
+        }
+    }
+}
+
+pub fn lower(program: &CheckedProgram) -> Program {
+    Program {
+        functions: program.functions.iter().map(lower_function).collect(),
+    }
+}
+
+fn lower_function(function: &CheckedFunction) -> Function {
+    let mut lowering = Lowering::new();
+    for stmt in &function.body {
+        lowering.lower_stmt(stmt);
+    }
+
+    Function {
+        name: function.name.clone(),
+        is_entry: function.name == "main",
+        param_offsets: function.param_offsets.clone(),
+        frame_size: function.frame_size,
+        vreg_count: lowering.next_vreg,
+        body: lowering.body,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod ast;
 mod codegen;
 mod config;
 mod diag;
+mod ir;
 mod lexer;
 mod parser;
 mod sema;
@@ -56,7 +57,8 @@ fn main() {
         std::process::exit(1);
     });
 
-    let assembly = backend.emit(&checked);
+    let ir_program = ir::lower(&checked);
+    let assembly = backend.emit(&ir_program);
 
     let file_stem = input_path.file_stem().unwrap_or_default().to_string_lossy();
     let output_path = PathBuf::from(

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,11 +68,11 @@ fn main() {
             .unwrap_or_else(|| format!("build/{}.s", file_stem)),
     );
 
-    if let Some(parent) = output_path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            eprintln!("error: could not create {}: {}", parent.display(), e);
-            std::process::exit(1);
-        }
+    if let Some(parent) = output_path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!("error: could not create {}: {}", parent.display(), e);
+        std::process::exit(1);
     }
 
     match std::fs::write(&output_path, assembly) {

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Compiles and runs every example, checking its exit code against the
+# expected value documented in a trailing "// exit N" comment. Meant to be
+# run inside `nix develop`.
+#
+# Deliberately doesn't use `set -e` - a single failing example shouldn't
+# abort the whole run, since we want a full pass/fail report at the end.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# path|expected -- "error" means it must fail to compile, "skip" means the
+# exit code is nondeterministic and shouldn't be checked at all.
+EXAMPLES=(
+  "examples/exit_code.cfy|42"
+  "examples/functions/basic_math.cfy|125"
+  "examples/logic/if_while.cfy|1"
+  "examples/logic/short_circuit.cfy|7"
+  "examples/math/arithmetic_folding.cfy|43"
+  "examples/math/div_by_zero.cfy|error"
+  "examples/pointers/read_write.cfy|42"
+  "examples/showcase.cfy|39"
+  "examples/structs/array_field.cfy|139"
+  "examples/structs/nested.cfy|32"
+  "examples/variables/basic_arrays.cfy|169"
+  "examples/variables/const_assign.cfy|error"
+  "examples/variables/mutability.cfy|41"
+  "examples/variables/syscall_expr.cfy|0"
+  "examples/variables/syscall_expr_pid.cfy|skip"
+)
+
+echo "Building comfyc..."
+RUSTFLAGS="-Awarnings" cargo build --quiet
+
+PASS=0
+FAIL=0
+SKIP=0
+
+for ENTRY in "${EXAMPLES[@]}"; do
+  FILE="${ENTRY%%|*}"
+  EXPECTED="${ENTRY##*|}"
+
+  if [ "$EXPECTED" = "skip" ]; then
+    echo "SKIP  $FILE (nondeterministic)"
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+
+  COMPILE_OUT="$(RUSTFLAGS="-Awarnings" cargo run --quiet -- "$FILE" 2>&1)"
+  COMPILE_STATUS=$?
+
+  if [ "$COMPILE_STATUS" -ne 0 ]; then
+    if [ "$EXPECTED" = "error" ]; then
+      echo "PASS  $FILE (compile error, as expected)"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL  $FILE - expected exit $EXPECTED, but compilation failed:"
+      echo "$COMPILE_OUT" | sed 's/^/         /'
+      FAIL=$((FAIL + 1))
+    fi
+    continue
+  fi
+
+  if [ "$EXPECTED" = "error" ]; then
+    echo "FAIL  $FILE - expected a compile error, but it compiled successfully"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  OUT_S="$(echo "$COMPILE_OUT" | grep -oP '(?<=Wrote )\S+\.s')"
+  "$SCRIPT_DIR/link_compile.sh" "$OUT_S" >/dev/null
+  BIN="build/$(basename "$OUT_S" .s)"
+
+  case "$(uname -m)" in
+    arm|armv6l|armv7l)
+      "$BIN" >/dev/null 2>&1
+      ACTUAL=$?
+      ;;
+    *)
+      QEMU_BIN="${QEMU_ARM:-qemu-arm}"
+      "$QEMU_BIN" "$BIN" >/dev/null 2>&1
+      ACTUAL=$?
+      ;;
+  esac
+
+  if [ "$ACTUAL" -eq "$EXPECTED" ]; then
+    echo "PASS  $FILE (exit $ACTUAL)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $FILE - expected exit $EXPECTED, got $ACTUAL"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Change bare push/pop stack machine to basic IR code generation step 

## Related issue(s)

Closes #142, #149

## Area

<!-- e.g. area: parser, area: codegen-arm32, area: ir, docs, ci, etc. -->

## Checklist

- [x] `cargo build` succeeds
- [x] Added/updated an example in `examples/` if this changes or adds language surface
- [x] Updated `README.md` (roadmap/language surface section) if applicable
- [x] This is **not** a breaking change to existing `.cfy` syntax/behavior, or it's labeled `breaking-change` and explained below

## Notes for reviewers

<!-- Anything that needs extra attention, open questions, follow-up work, etc. -->
