### PR TITLE
feat(#146): ir optimization passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ More examples in [`examples/`](./examples).
 **Syscalls**
 - `$syscall(nr, a0, a1, a2, a3, a4, a5)` is the sole compiler intrinsic, usable as a statement or an expression (its return value, from `r0`, can be captured). It maps directly onto the Linux ARM EABI syscall convention. Arguments may be pointers as well as integers, for passing buffer addresses. Named wrappers like `write`/`read`/`exit` will come back as ordinary standard-library functions once comfylang has a standard library.
 
+## Optimizations
+
+`comfyc` lowers checked ASTs to a flat, three-address IR before codegen, and runs the following passes on it to a fixpoint, entirely at compile time:
+
+- **Constant propagation** - through virtual registers and stack-local slots alike; a `let` binding that's provably constant is folded away entirely.
+- **Redundant load elimination** - a repeated read of an unmodified local becomes a cheap register copy instead of a stack reload.
+- **Branch folding** - an `if`/`while` condition that folds to a compile-time constant becomes an unconditional jump (or vanishes) instead of a runtime comparison.
+- **Common subexpression elimination** - a repeated computation over unchanged inputs is computed once and reused.
+- **Strength reduction** - multiplying by a compile-time power of two becomes a shift; `*0`/`*1` collapse to their trivial equivalents.
+- **Dead code elimination** - unused pure computations, unread stores, and unreachable code (after a `return`/unconditional jump) are all removed.
+- **Tail-call elimination** - a `return f(...)` in tail position reuses the current stack frame instead of growing the stack, so self-recursive tail calls run in constant space.
+
+Register allocation is a simple linear-scan allocator mapping virtual registers onto a handful of real ARM registers, spilling to the stack only once it runs out.
+
+
 ## Roadmap
 
 Planned, in rough order:
@@ -120,5 +135,5 @@ Planned, in rough order:
 7. ~~Pointers (`*T`, `&x`, `*p`)~~ ✅
 8. ~~Arrays (`[T; N]`, indexing)~~ ✅
 9. ~~`struct`s~~ ✅
-10. IR + optimization passes
+10. ~~IR + optimization passes (constant propagation, dead code/branch/store elimination, CSE, strength reduction, tail calls) + linear-scan register allocation~~ ✅
 11. Additional backends (x86_64, ...), standard library, self-hosting prep

--- a/examples/optimization/control_opt.cfy
+++ b/examples/optimization/control_opt.cfy
@@ -1,0 +1,8 @@
+fn main() {
+    let x = 5;
+    if x > 3 {
+        $syscall(1, 1, 0, 0, 0, 0, 0);
+    } else {
+        $syscall(1, 2, 0, 0, 0, 0, 0);
+    }
+}

--- a/examples/optimization/fold_const.cfy
+++ b/examples/optimization/fold_const.cfy
@@ -1,0 +1,6 @@
+fn main() {
+    let mut x = 5;
+    x = x + 3;
+    let y = x * 2;
+    $syscall(1, y, 0, 0, 0, 0, 0); // exit 16
+}

--- a/examples/optimization/opt_control_flow.cfy
+++ b/examples/optimization/opt_control_flow.cfy
@@ -1,0 +1,14 @@
+fn main() {
+    let y = 10;
+    let mut sum = add_numbers(5, y);
+
+    if sum > 10 {
+        sum = 5;
+    }
+
+    $syscall(1, 42, 0, 0, 0, 0, 0); // exit 42
+}
+
+fn add_numbers(a: int, b: int) -> int {
+    return a + b;
+}

--- a/examples/optimization/repeat_shifts.cfy
+++ b/examples/optimization/repeat_shifts.cfy
@@ -1,0 +1,8 @@
+fn scale(x: int) -> int {
+    return x * 8;
+}
+
+fn main() {
+    let r = scale(5); // 40
+    $syscall(1, r, 0, 0, 0, 0, 0);
+}

--- a/examples/optimization/sub_expr.cfy
+++ b/examples/optimization/sub_expr.cfy
@@ -1,0 +1,6 @@
+fn main() {
+    let x = 3;
+    let y = 4;
+    let a = (x + y) * (x + y);
+    $syscall(1, a, 0, 0, 0, 0, 0); // exit 49
+}

--- a/examples/optimization/sub_expr.cfy
+++ b/examples/optimization/sub_expr.cfy
@@ -1,6 +1,8 @@
+fn compute(x: int, y: int) -> int {
+    return (x + y) * (x + y);
+}
+
 fn main() {
-    let x = 3;
-    let y = 4;
-    let a = (x + y) * (x + y);
-    $syscall(1, a, 0, 0, 0, 0, 0); // exit 49
+    let r = compute(3, 4);
+    $syscall(1, r, 0, 0, 0, 0, 0); // exit 49
 }

--- a/examples/optimization/tail_calls.cfy
+++ b/examples/optimization/tail_calls.cfy
@@ -1,0 +1,11 @@
+fn count_down(n: int) -> int {
+    if n <= 0 {
+        return 0;
+    }
+    return count_down(n - 1);
+}
+
+fn main() {
+    let r = count_down(2000000); // would overflow the stack without TCO
+    $syscall(1, r, 0, 0, 0, 0, 0); // exit 0
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -18,14 +18,14 @@ impl TypeName {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
     Neg,   // -x
     Not,   // !x
     Deref, // *x
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinOp {
     Add,
     Sub,
@@ -34,7 +34,7 @@ pub enum BinOp {
     Rem,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompareOp {
     Eq, // ==
     Ne, // !=

--- a/src/codegen/arm32.rs
+++ b/src/codegen/arm32.rs
@@ -42,7 +42,7 @@ impl Backend for Arm32Backend {
             emitter.emit_function(function);
         }
 
-        emitter.out
+        crate::codegen::strip_redundant_movs(&emitter.out)
     }
 }
 

--- a/src/codegen/arm32.rs
+++ b/src/codegen/arm32.rs
@@ -8,9 +8,16 @@
 //! allocation (mapping hot virtual registers to `r4`-`r11` instead of
 //! memory) is a follow-up step.
 
-use crate::ast;
 use crate::codegen::Backend;
 use crate::ir::{self, VReg};
+use crate::regalloc::Location;
+use crate::{ast, regalloc};
+
+/// Physical registers available for the linear-scan allocator to hand out.
+/// Excluded: r0-r5 (used as internal scratch by various `Instr` cases,
+/// e.g. syscalls need r0-r5 simultaneously), r7 (hard-wired syscall
+/// number register), r11/fp (our frame pointer).
+const ALLOCATABLE_REGS: [&str; 4] = ["r6", "r8", "r9", "r10"];
 
 pub struct Arm32Backend;
 
@@ -24,6 +31,8 @@ impl Backend for Arm32Backend {
             out: String::new(),
             return_label: None,
             vreg_base: 0,
+            locations: Vec::new(),
+            saved_regs: String::new(),
         };
 
         emitter.out.push_str(".global _start\n");
@@ -47,31 +56,67 @@ fn label_for(name: &str) -> &str {
 struct Emitter {
     out: String,
     return_label: Option<String>,
-    /// Byte offset (from `fp`) where this function's local-variable frame
-    /// ends and its virtual-register spill slots begin.
     vreg_base: usize,
+    /// Where each virtual register currently lives, computed fresh per
+    /// function by the register allocator.
+    locations: Vec<Location>,
+    /// The exact `push {...}`/`pop {...}` register list used in this
+    /// function's prologue, so the epilogue can mirror it exactly.
+    saved_regs: String,
 }
 
 impl Emitter {
-    fn vreg_offset(&self, v: VReg) -> usize {
-        self.vreg_base + 4 * (v.0 as usize + 1)
+    fn spill_offset(&self, slot: usize) -> usize {
+        self.vreg_base + 4 * (slot + 1)
     }
 
     fn load(&mut self, reg: &str, v: VReg) {
-        let offset = self.vreg_offset(v);
-        self.out
-            .push_str(&format!("\tldr {}, [fp, #-{}]\n", reg, offset));
+        match self.locations[v.0 as usize] {
+            Location::Register(slot) => {
+                let src = ALLOCATABLE_REGS[slot as usize];
+                if src != reg {
+                    self.out.push_str(&format!("\tmov {}, {}\n", reg, src));
+                }
+            }
+            Location::Spill(slot) => {
+                let offset = self.spill_offset(slot);
+                self.out
+                    .push_str(&format!("\tldr {}, [fp, #-{}]\n", reg, offset));
+            }
+        }
     }
 
     fn store(&mut self, reg: &str, v: VReg) {
-        let offset = self.vreg_offset(v);
-        self.out
-            .push_str(&format!("\tstr {}, [fp, #-{}]\n", reg, offset));
+        match self.locations[v.0 as usize] {
+            Location::Register(slot) => {
+                let dst = ALLOCATABLE_REGS[slot as usize];
+                if dst != reg {
+                    self.out.push_str(&format!("\tmov {}, {}\n", dst, reg));
+                }
+            }
+            Location::Spill(slot) => {
+                let offset = self.spill_offset(slot);
+                self.out
+                    .push_str(&format!("\tstr {}, [fp, #-{}]\n", reg, offset));
+            }
+        }
     }
 
     fn emit_function(&mut self, function: &ir::Function) {
+        let allocation = regalloc::allocate(
+            &function.body,
+            function.vreg_count,
+            ALLOCATABLE_REGS.len() as u32,
+        );
         self.vreg_base = function.frame_size;
-        let total_frame = function.frame_size + 4 * function.vreg_count as usize;
+        let total_frame = function.frame_size + 4 * allocation.spill_count;
+        self.locations = allocation.locations;
+
+        let used_regs: Vec<&str> = ALLOCATABLE_REGS
+            .iter()
+            .zip(&allocation.used_registers)
+            .filter_map(|(reg, &used)| used.then_some(*reg))
+            .collect();
 
         self.out
             .push_str(&format!("{}:\n", label_for(&function.name)));
@@ -84,7 +129,13 @@ impl Emitter {
             }
             self.return_label = None;
         } else {
-            self.out.push_str("\tpush {fp, lr}\n");
+            self.saved_regs = if used_regs.is_empty() {
+                "fp, lr".to_string()
+            } else {
+                format!("{}, fp, lr", used_regs.join(", "))
+            };
+            self.out
+                .push_str(&format!("\tpush {{{}}}\n", self.saved_regs));
             self.out.push_str("\tmov fp, sp\n");
             if total_frame > 0 {
                 let aligned = (total_frame + 7) & !7;
@@ -106,7 +157,8 @@ impl Emitter {
         if let Some(label) = self.return_label.clone() {
             self.out.push_str(&format!("{}:\n", label));
             self.out.push_str("\tmov sp, fp\n");
-            self.out.push_str("\tpop {fp, lr}\n");
+            self.out
+                .push_str(&format!("\tpop {{{}}}\n", self.saved_regs));
             self.out.push_str("\tbx lr\n");
         }
     }

--- a/src/codegen/arm32.rs
+++ b/src/codegen/arm32.rs
@@ -283,6 +283,17 @@ impl Emitter {
                 self.out.push_str("\tstr r1, [r0]\n");
             }
 
+            ir::Instr::TailCall { name, args } => {
+                let regs = ["r0", "r1", "r2", "r3"];
+                for (reg, arg) in regs.iter().zip(args) {
+                    self.load(reg, *arg);
+                }
+                self.out.push_str("\tmov sp, fp\n");
+                self.out
+                    .push_str(&format!("\tpop {{{}}}\n", self.saved_regs));
+                self.out.push_str(&format!("\tb {}\n", label_for(name)));
+            }
+
             ir::Instr::Syscall { dst, args } => {
                 self.load("r7", args[0]);
                 let regs = ["r0", "r1", "r2", "r3", "r4", "r5"];

--- a/src/codegen/arm32.rs
+++ b/src/codegen/arm32.rs
@@ -216,6 +216,12 @@ impl Emitter {
                 self.store("r0", *dst);
             }
 
+            ir::Instr::Shl { dst, src, shift } => {
+                self.load("r0", *src);
+                self.out.push_str(&format!("\tlsl r0, r0, #{}\n", shift));
+                self.store("r0", *dst);
+            }
+
             ir::Instr::LoadLocal { dst, offset } => {
                 self.out
                     .push_str(&format!("\tldr r0, [fp, #-{}]\n", offset));

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6,3 +6,44 @@ pub trait Backend {
     fn name(&self) -> &'static str;
     fn emit(&self, program: &Program) -> String;
 }
+
+/// A text-level peephole pass: deletes a `mov B, A` line that immediately
+/// follows a `mov A, B` line, since the first already makes `A` and `B`
+/// equal, making the second a no-op. Backend-agnostic (any register-based
+/// backend built around a load/store abstraction like ours tends to
+/// produce exactly this redundancy at the boundary between instructions).
+pub fn strip_redundant_movs(asm: &str) -> String {
+    let lines: Vec<&str> = asm.lines().collect();
+    let mut out = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        if let Some((a, b)) = parse_mov(lines[i])
+            && i + 1 < lines.len()
+            && parse_mov(lines[i + 1]) == Some((b, a))
+        {
+            out.push(lines[i]);
+            i += 2; // drop the redundant second mov
+            continue;
+        }
+        out.push(lines[i]);
+        i += 1;
+    }
+
+    let mut result = out.join("\n");
+    result.push('\n');
+    result
+}
+
+/// Parses a `\tmov DST, SRC` line into `(dst, src)`. Returns `None` for
+/// anything else, including a `mov` with an immediate operand (`mov r0,
+/// #0`), which isn't a register-to-register move at all.
+fn parse_mov(line: &str) -> Option<(&str, &str)> {
+    let rest = line.trim_start().strip_prefix("mov ")?;
+    let (dst, src) = rest.split_once(',')?;
+    let src = src.trim();
+    if src.starts_with('#') {
+        return None;
+    }
+    Some((dst.trim(), src))
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -35,7 +35,11 @@ pub enum Instr {
         lhs: VReg,
         rhs: VReg,
     },
-
+    Shl {
+        dst: VReg,
+        src: VReg,
+        shift: u32,
+    },
     LoadLocal {
         dst: VReg,
         offset: usize,
@@ -101,6 +105,7 @@ impl Instr {
             | Instr::Unary { dst, .. }
             | Instr::Binary { dst, .. }
             | Instr::Compare { dst, .. }
+            | Instr::Shl { dst, .. }
             | Instr::LoadLocal { dst, .. }
             | Instr::LoadIndexed { dst, .. }
             | Instr::AddressOf { dst, .. }
@@ -123,7 +128,7 @@ impl Instr {
         match self {
             Instr::Const { .. } | Instr::LoadLocal { .. } | Instr::AddressOf { .. } => {}
             Instr::Copy { src, .. } => f(*src),
-            Instr::Unary { src, .. } => f(*src),
+            Instr::Unary { src, .. } | Instr::Shl { src, .. } => f(*src),
             Instr::Binary { lhs, rhs, .. } | Instr::Compare { lhs, rhs, .. } => {
                 f(*lhs);
                 f(*rhs);

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -92,6 +92,94 @@ pub enum Instr {
     Return(Option<VReg>),
 }
 
+impl Instr {
+    /// The virtual register this instruction defines (writes to), if any.
+    pub fn def(&self) -> Option<VReg> {
+        match self {
+            Instr::Const { dst, .. }
+            | Instr::Copy { dst, .. }
+            | Instr::Unary { dst, .. }
+            | Instr::Binary { dst, .. }
+            | Instr::Compare { dst, .. }
+            | Instr::LoadLocal { dst, .. }
+            | Instr::LoadIndexed { dst, .. }
+            | Instr::AddressOf { dst, .. }
+            | Instr::Load { dst, .. }
+            | Instr::Syscall { dst, .. } => Some(*dst),
+            Instr::Call { dst, .. } => *dst,
+            Instr::StoreLocal { .. }
+            | Instr::StoreIndexed { .. }
+            | Instr::Store { .. }
+            | Instr::Label(_)
+            | Instr::Jump(_)
+            | Instr::JumpIfZero { .. }
+            | Instr::JumpIfNotZero { .. }
+            | Instr::Return(_) => None,
+        }
+    }
+
+    /// Visits every virtual register this instruction *reads*.
+    pub fn for_each_use(&self, mut f: impl FnMut(VReg)) {
+        match self {
+            Instr::Const { .. } | Instr::LoadLocal { .. } | Instr::AddressOf { .. } => {}
+            Instr::Copy { src, .. } => f(*src),
+            Instr::Unary { src, .. } => f(*src),
+            Instr::Binary { lhs, rhs, .. } | Instr::Compare { lhs, rhs, .. } => {
+                f(*lhs);
+                f(*rhs);
+            }
+            Instr::StoreLocal { src, .. } => f(*src),
+            Instr::LoadIndexed { index, .. } => f(*index),
+            Instr::StoreIndexed { index, src, .. } => {
+                f(*index);
+                f(*src);
+            }
+            Instr::Load { addr, .. } => f(*addr),
+            Instr::Store { addr, src } => {
+                f(*addr);
+                f(*src);
+            }
+            Instr::Syscall { args, .. } => {
+                for a in args {
+                    f(*a);
+                }
+            }
+            Instr::Call { args, .. } => {
+                for a in args {
+                    f(*a);
+                }
+            }
+            Instr::Label(_) | Instr::Jump(_) => {}
+            Instr::JumpIfZero { cond, .. } | Instr::JumpIfNotZero { cond, .. } => f(*cond),
+            Instr::Return(v) => {
+                if let Some(v) = v {
+                    f(*v);
+                }
+            }
+        }
+    }
+
+    /// Whether this instruction is safe to delete outright when its result
+    /// is never used. `Syscall` and `Call` are deliberately excluded even
+    /// though they have a `dst` - they may perform I/O or other observable
+    /// side effects, so they must always run regardless of whether their
+    /// result is read.
+    pub fn is_pure(&self) -> bool {
+        matches!(
+            self,
+            Instr::Const { .. }
+                | Instr::Copy { .. }
+                | Instr::Unary { .. }
+                | Instr::Binary { .. }
+                | Instr::Compare { .. }
+                | Instr::LoadLocal { .. }
+                | Instr::LoadIndexed { .. }
+                | Instr::AddressOf { .. }
+                | Instr::Load { .. }
+        )
+    }
+}
+
 pub struct Function {
     pub name: String,
     pub is_entry: bool,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -82,7 +82,10 @@ pub enum Instr {
         name: String,
         args: Vec<VReg>,
     },
-
+    TailCall {
+        name: String,
+        args: Vec<VReg>,
+    },
     Label(String),
     Jump(String),
     JumpIfZero {
@@ -115,6 +118,7 @@ impl Instr {
             Instr::StoreLocal { .. }
             | Instr::StoreIndexed { .. }
             | Instr::Store { .. }
+            | Instr::TailCall { .. }
             | Instr::Label(_)
             | Instr::Jump(_)
             | Instr::JumpIfZero { .. }
@@ -143,6 +147,11 @@ impl Instr {
             Instr::Store { addr, src } => {
                 f(*addr);
                 f(*src);
+            }
+            Instr::TailCall { args, .. } => {
+                for a in args {
+                    f(*a);
+                }
             }
             Instr::Syscall { args, .. } => {
                 for a in args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod diag;
 mod ir;
 mod lexer;
+mod opt;
 mod parser;
 mod sema;
 
@@ -57,7 +58,8 @@ fn main() {
         std::process::exit(1);
     });
 
-    let ir_program = ir::lower(&checked);
+    let mut ir_program = ir::lower(&checked);
+    opt::optimize(&mut ir_program);
     let assembly = backend.emit(&ir_program);
 
     let file_stem = input_path.file_stem().unwrap_or_default().to_string_lossy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod diag;
 mod ir;
 mod lexer;
 mod parser;
+mod regalloc;
 mod sema;
 
 fn main() {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -380,19 +380,49 @@ enum CseKey {
     Compare(ast::CompareOp, u32, u32),
 }
 
+/// Resolves a vreg to the earliest vreg proven to hold the exact same
+/// value, by following any `Copy` chain recorded in `canon`.
+fn resolve(canon: &HashMap<u32, u32>, v: VReg) -> u32 {
+    let mut cur = v.0;
+    while let Some(&next) = canon.get(&cur) {
+        cur = next;
+    }
+    cur
+}
+
 /// Replaces a pure computation with a `Copy` from an earlier instruction
-/// that already computed the exact same thing, within the same
-/// straight-line run of code (bounded by the same invalidation points used
-/// elsewhere: a `Label` control-flow join, or any instruction whose effects
-/// on memory we can't fully reason about).
+/// that provably computed the exact same value from the exact same inputs.
+///
+/// Operand identity is checked through `canon`, a same-value chain built
+/// from `Copy` instructions - in particular, the ones our own
+/// store-to-load forwarding in `propagate_constants` introduces. Without
+/// it, two reads of the same unmodified local would look like different
+/// vregs and never match here.
+///
+/// A `Label` clears both caches: it's a control-flow join, and code
+/// reached from a different path may never have executed the earlier
+/// computation at all - reusing its vreg there would read an undefined
+/// register. Nothing else needs to invalidate this pass's state: unlike
+/// `known_locals` in `propagate_constants`, this only reasons about
+/// register values (which, aside from the `&&`/`||` exception guarded by
+/// `multi`, never change once defined), never memory - so a
+/// `Store`/`Call`/`Syscall` in between can't affect it.
 fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
+    let multi = multiply_defined_vregs(body);
+    let mut canon: HashMap<u32, u32> = HashMap::new();
     let mut available: HashMap<CseKey, VReg> = HashMap::new();
     let mut changed = false;
 
     for instr in body.iter_mut() {
         match instr {
+            Instr::Copy { dst, src } => {
+                if !multi.contains(&dst.0) {
+                    let root = resolve(&canon, *src);
+                    canon.insert(dst.0, root);
+                }
+            }
             Instr::Unary { dst, op, src } => {
-                let key = CseKey::Unary(*op, src.0);
+                let key = CseKey::Unary(*op, resolve(&canon, *src));
                 if let Some(&existing) = available.get(&key) {
                     let dst = *dst;
                     *instr = Instr::Copy { dst, src: existing };
@@ -402,7 +432,7 @@ fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
                 }
             }
             Instr::Binary { dst, op, lhs, rhs } => {
-                let key = CseKey::Binary(*op, lhs.0, rhs.0);
+                let key = CseKey::Binary(*op, resolve(&canon, *lhs), resolve(&canon, *rhs));
                 if let Some(&existing) = available.get(&key) {
                     let dst = *dst;
                     *instr = Instr::Copy { dst, src: existing };
@@ -412,7 +442,7 @@ fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
                 }
             }
             Instr::Compare { dst, op, lhs, rhs } => {
-                let key = CseKey::Compare(*op, lhs.0, rhs.0);
+                let key = CseKey::Compare(*op, resolve(&canon, *lhs), resolve(&canon, *rhs));
                 if let Some(&existing) = available.get(&key) {
                     let dst = *dst;
                     *instr = Instr::Copy { dst, src: existing };
@@ -421,12 +451,9 @@ fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
                     available.insert(key, *dst);
                 }
             }
-            Instr::Label(_)
-            | Instr::Store { .. }
-            | Instr::StoreIndexed { .. }
-            | Instr::Call { .. }
-            | Instr::Syscall { .. } => {
+            Instr::Label(_) => {
                 available.clear();
+                canon.clear();
             }
             _ => {}
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,12 +14,13 @@ fn optimize_function(function: &mut Function) {
     loop {
         let mut changed = false;
         changed |= propagate_constants(&mut function.body, function.vreg_count);
-        changed |= strength_reduce(&mut function.body, function.vreg_count); // NEW
+        changed |= strength_reduce(&mut function.body, function.vreg_count);
         changed |= fold_branches(&mut function.body, function.vreg_count);
         changed |= eliminate_common_subexprs(&mut function.body);
         changed |= remove_dead_stores(&mut function.body);
         changed |= remove_unused_pure_instrs(&mut function.body);
         changed |= remove_unreachable_code(&mut function.body);
+        changed |= convert_tail_calls(&mut function.body); // NEW
         if !changed {
             break;
         }
@@ -289,7 +290,7 @@ fn remove_unreachable_code(body: &mut Vec<Instr>) -> bool {
                 }
             }
             _ if unreachable => {} // drop it
-            Instr::Jump(_) | Instr::Return(_) => {
+            Instr::Jump(_) | Instr::Return(_) | Instr::TailCall { .. } => {
                 unreachable = true;
                 result.push(instr);
             }
@@ -538,6 +539,44 @@ fn strength_reduce(body: &mut [Instr], vreg_count: u32) -> bool {
             }
             _ => {}
         }
+    }
+
+    changed
+}
+
+/// Collapses `Call` immediately followed by a `Return` of that exact
+/// call's result (or a discarded-result call followed by a bare `Return`)
+/// into a single `TailCall`. Since a `return` statement always ends the
+/// function wherever it appears, any `Call` directly preceding one is
+/// already in tail position - no further reachability analysis needed.
+fn convert_tail_calls(body: &mut Vec<Instr>) -> bool {
+    let mut changed = false;
+    let mut i = 0;
+
+    while i + 1 < body.len() {
+        let is_tail_call = match (&body[i], &body[i + 1]) {
+            (
+                Instr::Call {
+                    dst: Some(call_dst),
+                    ..
+                },
+                Instr::Return(Some(ret_v)),
+            ) => call_dst == ret_v,
+            (Instr::Call { dst: None, .. }, Instr::Return(None)) => true,
+            _ => false,
+        };
+
+        if is_tail_call {
+            body.remove(i + 1); // the Return
+            let call = body.remove(i);
+            let Instr::Call { name, args, .. } = call else {
+                unreachable!("`is_tail_call` only true when body[i] was Instr::Call")
+            };
+            body.insert(i, Instr::TailCall { name, args });
+            changed = true;
+        }
+
+        i += 1;
     }
 
     changed

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -402,7 +402,7 @@ fn resolve(canon: &HashMap<u32, u32>, v: VReg) -> u32 {
 /// register values (which, aside from the `&&`/`||` exception guarded by
 /// `multi`, never change once defined), never memory - so a
 /// `Store`/`Call`/`Syscall` in between can't affect it.
-fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
+fn eliminate_common_subexprs(body: &mut [Instr]) -> bool {
     let multi = multiply_defined_vregs(body);
     let mut canon: HashMap<u32, u32> = HashMap::new();
     let mut available: HashMap<CseKey, VReg> = HashMap::new();

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,30 +1,142 @@
 //! IR-level optimization passes, run after lowering and before codegen.
 
+use crate::ast;
 use crate::ir::{Function, Instr, Program};
 use std::collections::HashSet;
 
 pub fn optimize(program: &mut Program) {
     for function in &mut program.functions {
-        eliminate_dead_code(function);
+        optimize_function(function);
     }
 }
 
-fn eliminate_dead_code(function: &mut Function) {
-    // Removing one dead instruction can make the instructions that fed it
-    // dead too, so iterate to a fixpoint.
+fn optimize_function(function: &mut Function) {
+    // Each pass can expose new opportunities for the others (e.g. folding
+    // a Binary into a Const can make its old operands unused), so iterate
+    // to a fixpoint.
     loop {
-        let before = function.body.len();
-        remove_unused_pure_instrs(&mut function.body);
-        remove_unreachable_code(&mut function.body);
-        if function.body.len() == before {
+        let mut changed = false;
+        changed |= propagate_constants(&mut function.body, function.vreg_count);
+        changed |= remove_unused_pure_instrs(&mut function.body);
+        changed |= remove_unreachable_code(&mut function.body);
+        if !changed {
             break;
         }
     }
 }
 
+/// Tracks which virtual registers are known, at this point in the program,
+/// to hold a specific compile-time-constant value, and rewrites any
+/// instruction whose inputs are all constant into a plain `Const`. Safe to
+/// run unconditionally: virtual registers are assigned exactly once, so a
+/// fact "vN == constant" is true for the rest of the function once recorded
+/// - unlike a stack slot, a VReg can never be overwritten with something
+/// else later.
+fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
+    let mut known: Vec<Option<i64>> = vec![None; vreg_count as usize];
+    let mut changed = false;
+
+    for instr in body.iter_mut() {
+        match instr {
+            Instr::Const { dst, value } => {
+                known[dst.0 as usize] = Some(*value);
+            }
+
+            Instr::Copy { dst, src } => {
+                if let Some(value) = known[src.0 as usize] {
+                    known[dst.0 as usize] = Some(value);
+                    *instr = Instr::Const { dst: *dst, value };
+                    changed = true;
+                }
+            }
+
+            Instr::Unary { dst, op, src } => {
+                if let Some(value) = known[src.0 as usize]
+                    && let Some(folded) = fold_unary(*op, value)
+                {
+                    known[dst.0 as usize] = Some(folded);
+                    *instr = Instr::Const {
+                        dst: *dst,
+                        value: folded,
+                    };
+                    changed = true;
+                }
+            }
+
+            Instr::Binary { dst, op, lhs, rhs } => {
+                if let (Some(l), Some(r)) = (known[lhs.0 as usize], known[rhs.0 as usize])
+                    && let Some(folded) = fold_binary(*op, l, r)
+                {
+                    known[dst.0 as usize] = Some(folded);
+                    *instr = Instr::Const {
+                        dst: *dst,
+                        value: folded,
+                    };
+                    changed = true;
+                }
+            }
+
+            Instr::Compare { dst, op, lhs, rhs } => {
+                if let (Some(l), Some(r)) = (known[lhs.0 as usize], known[rhs.0 as usize]) {
+                    let result = fold_compare(*op, l, r);
+                    known[dst.0 as usize] = Some(result);
+                    *instr = Instr::Const {
+                        dst: *dst,
+                        value: result,
+                    };
+                    changed = true;
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    changed
+}
+
+/// Whether a value fits in the 32-bit registers arm32 actually has - the
+/// same constraint `sema::to_checked_const` enforces on literals.
+fn fits_i32(value: i64) -> bool {
+    i32::try_from(value).is_ok()
+}
+
+fn fold_unary(op: ast::UnaryOp, value: i64) -> Option<i64> {
+    match op {
+        ast::UnaryOp::Neg => value.checked_neg().filter(|v| fits_i32(*v)),
+        ast::UnaryOp::Not => Some(value ^ 1),
+        ast::UnaryOp::Deref => None, // never appears as Instr::Unary
+    }
+}
+
+fn fold_binary(op: ast::BinOp, lhs: i64, rhs: i64) -> Option<i64> {
+    let result = match op {
+        ast::BinOp::Add => lhs.checked_add(rhs)?,
+        ast::BinOp::Sub => lhs.checked_sub(rhs)?,
+        ast::BinOp::Mul => lhs.checked_mul(rhs)?,
+        // sema rejects runtime division/remainder outright, so a Binary
+        // instruction with these ops can never reach the IR.
+        ast::BinOp::Div | ast::BinOp::Rem => return None,
+    };
+    fits_i32(result).then_some(result)
+}
+
+fn fold_compare(op: ast::CompareOp, lhs: i64, rhs: i64) -> i64 {
+    let result = match op {
+        ast::CompareOp::Eq => lhs == rhs,
+        ast::CompareOp::Ne => lhs != rhs,
+        ast::CompareOp::Lt => lhs < rhs,
+        ast::CompareOp::Le => lhs <= rhs,
+        ast::CompareOp::Gt => lhs > rhs,
+        ast::CompareOp::Ge => lhs >= rhs,
+    };
+    result as i64
+}
+
 /// Drops any pure instruction whose result is never read by a later
 /// instruction in the function.
-fn remove_unused_pure_instrs(body: &mut Vec<Instr>) {
+fn remove_unused_pure_instrs(body: &mut Vec<Instr>) -> bool {
+    let before = body.len();
     let mut used: HashSet<u32> = HashSet::new();
     for instr in body.iter() {
         instr.for_each_use(|v| {
@@ -36,11 +148,14 @@ fn remove_unused_pure_instrs(body: &mut Vec<Instr>) {
         Some(dst) if instr.is_pure() => used.contains(&dst.0),
         _ => true,
     });
+
+    body.len() != before
 }
 
 /// Drops instructions that can never execute: anything between an
 /// unconditional `Jump`/`Return` and the next `Label`.
-fn remove_unreachable_code(body: &mut Vec<Instr>) {
+fn remove_unreachable_code(body: &mut Vec<Instr>) -> bool {
+    let before = body.len();
     let mut result = Vec::with_capacity(body.len());
     let mut unreachable = false;
 
@@ -60,4 +175,5 @@ fn remove_unreachable_code(body: &mut Vec<Instr>) {
     }
 
     *body = result;
+    body.len() != before
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -11,12 +11,10 @@ pub fn optimize(program: &mut Program) {
 }
 
 fn optimize_function(function: &mut Function) {
-    // Each pass can expose new opportunities for the others (e.g. folding
-    // a Binary into a Const can make its old operands unused), so iterate
-    // to a fixpoint.
     loop {
         let mut changed = false;
         changed |= propagate_constants(&mut function.body, function.vreg_count);
+        changed |= fold_branches(&mut function.body, function.vreg_count);
         changed |= remove_unused_pure_instrs(&mut function.body);
         changed |= remove_unreachable_code(&mut function.body);
         if !changed {
@@ -26,6 +24,7 @@ fn optimize_function(function: &mut Function) {
 }
 
 fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
+    let multi = multiply_defined_vregs(body);
     let mut known_vregs: Vec<Option<i64>> = vec![None; vreg_count as usize];
     let mut known_locals: HashMap<usize, i64> = HashMap::new();
     let mut changed = false;
@@ -33,11 +32,15 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
     for instr in body.iter_mut() {
         match instr {
             Instr::Const { dst, value } => {
-                known_vregs[dst.0 as usize] = Some(*value);
+                if !multi.contains(&dst.0) {
+                    known_vregs[dst.0 as usize] = Some(*value);
+                }
             }
 
             Instr::Copy { dst, src } => {
-                if let Some(value) = known_vregs[src.0 as usize] {
+                if !multi.contains(&dst.0)
+                    && let Some(value) = known_vregs[src.0 as usize]
+                {
                     known_vregs[dst.0 as usize] = Some(value);
                     *instr = Instr::Const { dst: *dst, value };
                     changed = true;
@@ -162,6 +165,60 @@ fn fold_compare(op: ast::CompareOp, lhs: i64, rhs: i64) -> i64 {
     result as i64
 }
 
+enum BranchDecision {
+    AlwaysJump(String),
+    NeverJump,
+    Unknown,
+}
+
+/// Simplifies a conditional jump whose condition is a compile-time constant
+/// into either an unconditional `Jump` or nothing at all.
+fn fold_branches(body: &mut Vec<Instr>, vreg_count: u32) -> bool {
+    let multi = multiply_defined_vregs(body);
+    let mut known: Vec<Option<i64>> = vec![None; vreg_count as usize];
+    let mut changed = false;
+    let mut i = 0;
+
+    while i < body.len() {
+        let decision = match &body[i] {
+            Instr::Const { dst, value } => {
+                if !multi.contains(&dst.0) {
+                    known[dst.0 as usize] = Some(*value);
+                }
+                BranchDecision::Unknown
+            }
+            Instr::JumpIfZero { cond, label } => match known[cond.0 as usize] {
+                Some(0) => BranchDecision::AlwaysJump(label.clone()),
+                Some(_) => BranchDecision::NeverJump,
+                None => BranchDecision::Unknown,
+            },
+            Instr::JumpIfNotZero { cond, label } => match known[cond.0 as usize] {
+                Some(v) if v != 0 => BranchDecision::AlwaysJump(label.clone()),
+                Some(_) => BranchDecision::NeverJump,
+                None => BranchDecision::Unknown,
+            },
+            _ => BranchDecision::Unknown,
+        };
+
+        match decision {
+            BranchDecision::AlwaysJump(label) => {
+                body[i] = Instr::Jump(label);
+                changed = true;
+                i += 1;
+            }
+            BranchDecision::NeverJump => {
+                body.remove(i);
+                changed = true;
+            }
+            BranchDecision::Unknown => {
+                i += 1;
+            }
+        }
+    }
+
+    changed
+}
+
 /// Drops any pure instruction whose result is never read by a later
 /// instruction in the function.
 fn remove_unused_pure_instrs(body: &mut Vec<Instr>) -> bool {
@@ -181,18 +238,36 @@ fn remove_unused_pure_instrs(body: &mut Vec<Instr>) -> bool {
     body.len() != before
 }
 
-/// Drops instructions that can never execute: anything between an
-/// unconditional `Jump`/`Return` and the next `Label`.
 fn remove_unreachable_code(body: &mut Vec<Instr>) -> bool {
     let before = body.len();
+
+    // A label only "rescues" code out of the unreachable state if it's
+    // actually targeted by some jump in this function - otherwise reaching
+    // it would require falling through from code already proven dead.
+    let mut referenced: HashSet<String> = HashSet::new();
+    for instr in body.iter() {
+        match instr {
+            Instr::Jump(label)
+            | Instr::JumpIfZero { label, .. }
+            | Instr::JumpIfNotZero { label, .. } => {
+                referenced.insert(label.clone());
+            }
+            _ => {}
+        }
+    }
+
     let mut result = Vec::with_capacity(body.len());
     let mut unreachable = false;
 
     for instr in body.drain(..) {
-        match instr {
-            Instr::Label(_) => {
-                unreachable = false;
-                result.push(instr);
+        match &instr {
+            Instr::Label(name) => {
+                if referenced.contains(name) {
+                    unreachable = false;
+                }
+                if !unreachable {
+                    result.push(instr);
+                }
             }
             _ if unreachable => {} // drop it
             Instr::Jump(_) | Instr::Return(_) => {
@@ -205,4 +280,24 @@ fn remove_unreachable_code(body: &mut Vec<Instr>) -> bool {
 
     *body = result;
     body.len() != before
+}
+
+/// Virtual registers written by more than one instruction. Almost every
+/// vreg has exactly one definition site (lowering always allocates a fresh
+/// one via `new_vreg()`) - the one exception is `&&`/`||`, which reuse a
+/// single `dst` across two instructions on two different control-flow
+/// paths. A flat, flow-insensitive forward scan can't safely reason about
+/// those: which instruction "wins" depends on which path executes, so such
+/// a vreg must never be treated as provably constant.
+fn multiply_defined_vregs(body: &[Instr]) -> HashSet<u32> {
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut multi: HashSet<u32> = HashSet::new();
+    for instr in body {
+        if let Some(dst) = instr.def()
+            && !seen.insert(dst.0)
+        {
+            multi.insert(dst.0);
+        }
+    }
+    multi
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -14,8 +14,9 @@ fn optimize_function(function: &mut Function) {
     loop {
         let mut changed = false;
         changed |= propagate_constants(&mut function.body, function.vreg_count);
+        changed |= strength_reduce(&mut function.body, function.vreg_count); // NEW
         changed |= fold_branches(&mut function.body, function.vreg_count);
-        changed |= eliminate_common_subexprs(&mut function.body); // NEW
+        changed |= eliminate_common_subexprs(&mut function.body);
         changed |= remove_dead_stores(&mut function.body);
         changed |= remove_unused_pure_instrs(&mut function.body);
         changed |= remove_unreachable_code(&mut function.body);
@@ -365,19 +366,12 @@ fn remove_dead_stores(body: &mut Vec<Instr>) -> bool {
     body.len() != before
 }
 
-/// Key identifying a pure computation by its operator and operand vregs.
-/// Two instructions with the same key are guaranteed to produce the same
-/// result: our IR only gives a vreg a second definition in the `&&`/`||`
-/// case, and even then, by the time that vreg is *read* again its value is
-/// already fixed for the remainder of straight-line code (the two
-/// definitions live on mutually exclusive control-flow paths that have
-/// already resolved into one by the join point) - so operand identity here
-/// is as good as an SSA guarantee.
 #[derive(PartialEq, Eq, Hash)]
 enum CseKey {
     Unary(ast::UnaryOp, u32),
     Binary(ast::BinOp, u32, u32),
     Compare(ast::CompareOp, u32, u32),
+    Shl(u32, u32), // (resolved src, shift amount)
 }
 
 /// Resolves a vreg to the earliest vreg proven to hold the exact same
@@ -451,9 +445,96 @@ fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
                     available.insert(key, *dst);
                 }
             }
+            Instr::Shl { dst, src, shift } => {
+                let key = CseKey::Shl(resolve(&canon, *src), *shift);
+                if let Some(&existing) = available.get(&key) {
+                    let dst = *dst;
+                    *instr = Instr::Copy { dst, src: existing };
+                    changed = true;
+                } else {
+                    available.insert(key, *dst);
+                }
+            }
             Instr::Label(_) => {
                 available.clear();
                 canon.clear();
+            }
+            _ => {}
+        }
+    }
+
+    changed
+}
+
+enum Reduced {
+    Const(i64),
+    Copy(VReg),
+    Shl(VReg, u32),
+}
+
+fn is_power_of_two(value: i64) -> bool {
+    value > 0 && (value & (value - 1)) == 0
+}
+
+/// Given one operand's known constant `value` and the other (unknown)
+/// operand `other`, decides how to rewrite `other * value` more cheaply -
+/// or `None` if `value` isn't a special case worth rewriting.
+fn reduce_mul(value: i64, other: VReg) -> Option<Reduced> {
+    if value == 0 {
+        Some(Reduced::Const(0))
+    } else if value == 1 {
+        Some(Reduced::Copy(other))
+    } else if is_power_of_two(value) {
+        Some(Reduced::Shl(other, value.trailing_zeros()))
+    } else {
+        None
+    }
+}
+
+/// Rewrites a multiply by a compile-time-known power of two (or the
+/// degenerate `*0`/`*1` cases) into a cheaper equivalent. ARM's `mul`
+/// instruction can't take an immediate operand at all, so a multiply by a
+/// runtime-unknown value against a literal already has to load that
+/// literal into a register first - this saves an instruction whenever it
+/// applies, not just cycles.
+fn strength_reduce(body: &mut [Instr], vreg_count: u32) -> bool {
+    let multi = multiply_defined_vregs(body);
+    let mut known_vregs: Vec<Option<i64>> = vec![None; vreg_count as usize];
+    let mut changed = false;
+
+    for instr in body.iter_mut() {
+        match instr {
+            Instr::Const { dst, value } => {
+                if !multi.contains(&dst.0) {
+                    known_vregs[dst.0 as usize] = Some(*value);
+                }
+            }
+            Instr::Copy { dst, src } => {
+                if !multi.contains(&dst.0)
+                    && let Some(value) = known_vregs[src.0 as usize]
+                {
+                    known_vregs[dst.0 as usize] = Some(value);
+                }
+            }
+            Instr::Binary {
+                dst,
+                op: ast::BinOp::Mul,
+                lhs,
+                rhs,
+            } => {
+                let reduced = known_vregs[rhs.0 as usize]
+                    .and_then(|v| reduce_mul(v, *lhs))
+                    .or_else(|| known_vregs[lhs.0 as usize].and_then(|v| reduce_mul(v, *rhs)));
+
+                if let Some(new_instr) = reduced {
+                    let dst = *dst;
+                    *instr = match new_instr {
+                        Reduced::Const(value) => Instr::Const { dst, value },
+                        Reduced::Copy(src) => Instr::Copy { dst, src },
+                        Reduced::Shl(src, shift) => Instr::Shl { dst, src, shift },
+                    };
+                    changed = true;
+                }
             }
             _ => {}
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -2,7 +2,7 @@
 
 use crate::ast;
 use crate::ir::{Function, Instr, Program};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 pub fn optimize(program: &mut Program) {
     for function in &mut program.functions {
@@ -25,36 +25,30 @@ fn optimize_function(function: &mut Function) {
     }
 }
 
-/// Tracks which virtual registers are known, at this point in the program,
-/// to hold a specific compile-time-constant value, and rewrites any
-/// instruction whose inputs are all constant into a plain `Const`. Safe to
-/// run unconditionally: virtual registers are assigned exactly once, so a
-/// fact "vN == constant" is true for the rest of the function once recorded
-/// - unlike a stack slot, a VReg can never be overwritten with something
-/// else later.
 fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
-    let mut known: Vec<Option<i64>> = vec![None; vreg_count as usize];
+    let mut known_vregs: Vec<Option<i64>> = vec![None; vreg_count as usize];
+    let mut known_locals: HashMap<usize, i64> = HashMap::new();
     let mut changed = false;
 
     for instr in body.iter_mut() {
         match instr {
             Instr::Const { dst, value } => {
-                known[dst.0 as usize] = Some(*value);
+                known_vregs[dst.0 as usize] = Some(*value);
             }
 
             Instr::Copy { dst, src } => {
-                if let Some(value) = known[src.0 as usize] {
-                    known[dst.0 as usize] = Some(value);
+                if let Some(value) = known_vregs[src.0 as usize] {
+                    known_vregs[dst.0 as usize] = Some(value);
                     *instr = Instr::Const { dst: *dst, value };
                     changed = true;
                 }
             }
 
             Instr::Unary { dst, op, src } => {
-                if let Some(value) = known[src.0 as usize]
+                if let Some(value) = known_vregs[src.0 as usize]
                     && let Some(folded) = fold_unary(*op, value)
                 {
-                    known[dst.0 as usize] = Some(folded);
+                    known_vregs[dst.0 as usize] = Some(folded);
                     *instr = Instr::Const {
                         dst: *dst,
                         value: folded,
@@ -64,10 +58,11 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
             }
 
             Instr::Binary { dst, op, lhs, rhs } => {
-                if let (Some(l), Some(r)) = (known[lhs.0 as usize], known[rhs.0 as usize])
+                if let (Some(l), Some(r)) =
+                    (known_vregs[lhs.0 as usize], known_vregs[rhs.0 as usize])
                     && let Some(folded) = fold_binary(*op, l, r)
                 {
-                    known[dst.0 as usize] = Some(folded);
+                    known_vregs[dst.0 as usize] = Some(folded);
                     *instr = Instr::Const {
                         dst: *dst,
                         value: folded,
@@ -77,15 +72,49 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
             }
 
             Instr::Compare { dst, op, lhs, rhs } => {
-                if let (Some(l), Some(r)) = (known[lhs.0 as usize], known[rhs.0 as usize]) {
+                if let (Some(l), Some(r)) =
+                    (known_vregs[lhs.0 as usize], known_vregs[rhs.0 as usize])
+                {
                     let result = fold_compare(*op, l, r);
-                    known[dst.0 as usize] = Some(result);
+                    known_vregs[dst.0 as usize] = Some(result);
                     *instr = Instr::Const {
                         dst: *dst,
                         value: result,
                     };
                     changed = true;
                 }
+            }
+
+            Instr::LoadLocal { dst, offset } => {
+                if let Some(&value) = known_locals.get(offset) {
+                    known_vregs[dst.0 as usize] = Some(value);
+                    *instr = Instr::Const { dst: *dst, value };
+                    changed = true;
+                }
+            }
+
+            Instr::StoreLocal { offset, src } => match known_vregs[src.0 as usize] {
+                Some(value) => {
+                    known_locals.insert(*offset, value);
+                }
+                None => {
+                    known_locals.remove(offset);
+                }
+            },
+
+            // Control-flow join we can't reason about with a flat
+            // instruction list - forget everything we assumed about locals.
+            Instr::Label(_) => known_locals.clear(),
+
+            // Writes through a raw pointer or an unchecked index could touch
+            // any local in the frame; a call or syscall could write through
+            // a pointer argument internally. None of these are analyzable
+            // here, so conservatively forget every tracked local.
+            Instr::Store { .. }
+            | Instr::StoreIndexed { .. }
+            | Instr::Call { .. }
+            | Instr::Syscall { .. } => {
+                known_locals.clear();
             }
 
             _ => {}

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -15,6 +15,7 @@ fn optimize_function(function: &mut Function) {
         let mut changed = false;
         changed |= propagate_constants(&mut function.body, function.vreg_count);
         changed |= fold_branches(&mut function.body, function.vreg_count);
+        changed |= eliminate_common_subexprs(&mut function.body); // NEW
         changed |= remove_dead_stores(&mut function.body);
         changed |= remove_unused_pure_instrs(&mut function.body);
         changed |= remove_unreachable_code(&mut function.body);
@@ -362,4 +363,74 @@ fn remove_dead_stores(body: &mut Vec<Instr>) -> bool {
     });
 
     body.len() != before
+}
+
+/// Key identifying a pure computation by its operator and operand vregs.
+/// Two instructions with the same key are guaranteed to produce the same
+/// result: our IR only gives a vreg a second definition in the `&&`/`||`
+/// case, and even then, by the time that vreg is *read* again its value is
+/// already fixed for the remainder of straight-line code (the two
+/// definitions live on mutually exclusive control-flow paths that have
+/// already resolved into one by the join point) - so operand identity here
+/// is as good as an SSA guarantee.
+#[derive(PartialEq, Eq, Hash)]
+enum CseKey {
+    Unary(ast::UnaryOp, u32),
+    Binary(ast::BinOp, u32, u32),
+    Compare(ast::CompareOp, u32, u32),
+}
+
+/// Replaces a pure computation with a `Copy` from an earlier instruction
+/// that already computed the exact same thing, within the same
+/// straight-line run of code (bounded by the same invalidation points used
+/// elsewhere: a `Label` control-flow join, or any instruction whose effects
+/// on memory we can't fully reason about).
+fn eliminate_common_subexprs(body: &mut Vec<Instr>) -> bool {
+    let mut available: HashMap<CseKey, VReg> = HashMap::new();
+    let mut changed = false;
+
+    for instr in body.iter_mut() {
+        match instr {
+            Instr::Unary { dst, op, src } => {
+                let key = CseKey::Unary(*op, src.0);
+                if let Some(&existing) = available.get(&key) {
+                    let dst = *dst;
+                    *instr = Instr::Copy { dst, src: existing };
+                    changed = true;
+                } else {
+                    available.insert(key, *dst);
+                }
+            }
+            Instr::Binary { dst, op, lhs, rhs } => {
+                let key = CseKey::Binary(*op, lhs.0, rhs.0);
+                if let Some(&existing) = available.get(&key) {
+                    let dst = *dst;
+                    *instr = Instr::Copy { dst, src: existing };
+                    changed = true;
+                } else {
+                    available.insert(key, *dst);
+                }
+            }
+            Instr::Compare { dst, op, lhs, rhs } => {
+                let key = CseKey::Compare(*op, lhs.0, rhs.0);
+                if let Some(&existing) = available.get(&key) {
+                    let dst = *dst;
+                    *instr = Instr::Copy { dst, src: existing };
+                    changed = true;
+                } else {
+                    available.insert(key, *dst);
+                }
+            }
+            Instr::Label(_)
+            | Instr::Store { .. }
+            | Instr::StoreIndexed { .. }
+            | Instr::Call { .. }
+            | Instr::Syscall { .. } => {
+                available.clear();
+            }
+            _ => {}
+        }
+    }
+
+    changed
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,7 +1,7 @@
 //! IR-level optimization passes, run after lowering and before codegen.
 
 use crate::ast;
-use crate::ir::{Function, Instr, Program};
+use crate::ir::{Function, Instr, Program, VReg};
 use std::collections::{HashMap, HashSet};
 
 pub fn optimize(program: &mut Program) {
@@ -28,6 +28,7 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
     let multi = multiply_defined_vregs(body);
     let mut known_vregs: Vec<Option<i64>> = vec![None; vreg_count as usize];
     let mut known_locals: HashMap<usize, i64> = HashMap::new();
+    let mut known_local_vregs: HashMap<usize, VReg> = HashMap::new();
     let mut changed = false;
 
     for instr in body.iter_mut() {
@@ -94,21 +95,35 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
                     known_vregs[dst.0 as usize] = Some(value);
                     *instr = Instr::Const { dst: *dst, value };
                     changed = true;
+                } else if let Some(&src) = known_local_vregs.get(offset) {
+                    let dst = *dst;
+                    let offset = *offset;
+                    *instr = Instr::Copy { dst, src };
+                    known_local_vregs.insert(offset, dst);
+                    changed = true;
+                } else {
+                    known_local_vregs.insert(*offset, *dst);
                 }
             }
 
-            Instr::StoreLocal { offset, src } => match known_vregs[src.0 as usize] {
-                Some(value) => {
-                    known_locals.insert(*offset, value);
+            Instr::StoreLocal { offset, src } => {
+                match known_vregs[src.0 as usize] {
+                    Some(value) => {
+                        known_locals.insert(*offset, value);
+                    }
+                    None => {
+                        known_locals.remove(offset);
+                    }
                 }
-                None => {
-                    known_locals.remove(offset);
-                }
-            },
+                known_local_vregs.insert(*offset, *src);
+            }
 
             // Control-flow join we can't reason about with a flat
             // instruction list - forget everything we assumed about locals.
-            Instr::Label(_) => known_locals.clear(),
+            Instr::Label(_) => {
+                known_locals.clear();
+                known_local_vregs.clear();
+            }
 
             // Writes through a raw pointer or an unchecked index could touch
             // any local in the frame; a call or syscall could write through
@@ -119,6 +134,7 @@ fn propagate_constants(body: &mut [Instr], vreg_count: u32) -> bool {
             | Instr::Call { .. }
             | Instr::Syscall { .. } => {
                 known_locals.clear();
+                known_local_vregs.clear();
             }
 
             _ => {}

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,0 +1,63 @@
+//! IR-level optimization passes, run after lowering and before codegen.
+
+use crate::ir::{Function, Instr, Program};
+use std::collections::HashSet;
+
+pub fn optimize(program: &mut Program) {
+    for function in &mut program.functions {
+        eliminate_dead_code(function);
+    }
+}
+
+fn eliminate_dead_code(function: &mut Function) {
+    // Removing one dead instruction can make the instructions that fed it
+    // dead too, so iterate to a fixpoint.
+    loop {
+        let before = function.body.len();
+        remove_unused_pure_instrs(&mut function.body);
+        remove_unreachable_code(&mut function.body);
+        if function.body.len() == before {
+            break;
+        }
+    }
+}
+
+/// Drops any pure instruction whose result is never read by a later
+/// instruction in the function.
+fn remove_unused_pure_instrs(body: &mut Vec<Instr>) {
+    let mut used: HashSet<u32> = HashSet::new();
+    for instr in body.iter() {
+        instr.for_each_use(|v| {
+            used.insert(v.0);
+        });
+    }
+
+    body.retain(|instr| match instr.def() {
+        Some(dst) if instr.is_pure() => used.contains(&dst.0),
+        _ => true,
+    });
+}
+
+/// Drops instructions that can never execute: anything between an
+/// unconditional `Jump`/`Return` and the next `Label`.
+fn remove_unreachable_code(body: &mut Vec<Instr>) {
+    let mut result = Vec::with_capacity(body.len());
+    let mut unreachable = false;
+
+    for instr in body.drain(..) {
+        match instr {
+            Instr::Label(_) => {
+                unreachable = false;
+                result.push(instr);
+            }
+            _ if unreachable => {} // drop it
+            Instr::Jump(_) | Instr::Return(_) => {
+                unreachable = true;
+                result.push(instr);
+            }
+            _ => result.push(instr),
+        }
+    }
+
+    *body = result;
+}

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -15,6 +15,7 @@ fn optimize_function(function: &mut Function) {
         let mut changed = false;
         changed |= propagate_constants(&mut function.body, function.vreg_count);
         changed |= fold_branches(&mut function.body, function.vreg_count);
+        changed |= remove_dead_stores(&mut function.body);
         changed |= remove_unused_pure_instrs(&mut function.body);
         changed |= remove_unreachable_code(&mut function.body);
         if !changed {
@@ -300,4 +301,49 @@ fn multiply_defined_vregs(body: &[Instr]) -> HashSet<u32> {
         }
     }
     multi
+}
+
+/// Removes a `StoreLocal` whose value can never be observed: its offset's
+/// address is never taken (so no pointer could alias it), no `LoadLocal`
+/// anywhere in the function ever reads that offset, and it isn't within
+/// the range of any array/struct-field accessed through a runtime index.
+fn remove_dead_stores(body: &mut Vec<Instr>) -> bool {
+    let before = body.len();
+
+    let mut address_taken: HashSet<usize> = HashSet::new();
+    let mut loaded: HashSet<usize> = HashSet::new();
+    let mut indexed_base_offsets: Vec<usize> = Vec::new();
+
+    for instr in body.iter() {
+        match instr {
+            Instr::AddressOf { offset, .. } => {
+                address_taken.insert(*offset);
+            }
+            Instr::LoadLocal { offset, .. } => {
+                loaded.insert(*offset);
+            }
+            Instr::LoadIndexed { base_offset, .. } | Instr::StoreIndexed { base_offset, .. } => {
+                indexed_base_offsets.push(*base_offset);
+            }
+            _ => {}
+        }
+    }
+
+    // Array elements sit at `base_offset + i * elem_size` for increasing
+    // `i`, but the IR doesn't carry the array's length, so we can't know
+    // each array's exact upper bound. Conservatively protect every offset
+    // at or above the smallest indexed base seen - it might be an element
+    // reached via a runtime index we can't reason about further.
+    let indexed_cutoff = indexed_base_offsets.into_iter().min();
+
+    body.retain(|instr| match instr {
+        Instr::StoreLocal { offset, .. } => {
+            address_taken.contains(offset)
+                || loaded.contains(offset)
+                || indexed_cutoff.is_some_and(|cutoff| *offset >= cutoff)
+        }
+        _ => true,
+    });
+
+    body.len() != before
 }

--- a/src/regalloc.rs
+++ b/src/regalloc.rs
@@ -71,6 +71,11 @@ fn for_each_vreg(instr: &Instr, mut f: impl FnMut(VReg)) {
             f(*addr);
             f(*src);
         }
+        Instr::TailCall { args, .. } => {
+            for a in args {
+                f(*a);
+            }
+        }
         Instr::Syscall { dst, args } => {
             f(*dst);
             for a in args {

--- a/src/regalloc.rs
+++ b/src/regalloc.rs
@@ -38,7 +38,7 @@ fn for_each_vreg(instr: &Instr, mut f: impl FnMut(VReg)) {
             f(*dst);
             f(*src);
         }
-        Instr::Unary { dst, src, .. } => {
+        Instr::Unary { dst, src, .. } | Instr::Shl { dst, src, .. } => {
             f(*dst);
             f(*src);
         }

--- a/src/regalloc.rs
+++ b/src/regalloc.rs
@@ -1,0 +1,181 @@
+//! A simple linear-scan register allocator, operating on the flat IR.
+//! Backend-agnostic: it just assigns each virtual register either one of
+//! `num_registers` abstract physical "slots" or a spill slot, based on
+//! textual live ranges. The backend maps slot indices to real register
+//! names.
+
+use crate::ir::{Instr, VReg};
+
+#[derive(Clone, Copy)]
+pub enum Location {
+    Register(u32),
+    Spill(usize),
+}
+
+pub struct Allocation {
+    /// Location of each virtual register, indexed by `VReg.0`.
+    pub locations: Vec<Location>,
+    /// Which physical register slots (0..num_registers) ended up used at
+    /// least once - the backend uses this to decide what to save/restore
+    /// in the function's prologue/epilogue.
+    pub used_registers: Vec<bool>,
+    /// How many spill slots were needed.
+    pub spill_count: usize,
+}
+
+struct Interval {
+    vreg: VReg,
+    start: usize,
+    end: usize,
+}
+
+/// Visits every virtual register mentioned by an instruction, def or use
+/// alike - for live-range purposes we don't need to distinguish the two.
+fn for_each_vreg(instr: &Instr, mut f: impl FnMut(VReg)) {
+    match instr {
+        Instr::Const { dst, .. } => f(*dst),
+        Instr::Copy { dst, src } => {
+            f(*dst);
+            f(*src);
+        }
+        Instr::Unary { dst, src, .. } => {
+            f(*dst);
+            f(*src);
+        }
+        Instr::Binary { dst, lhs, rhs, .. } => {
+            f(*dst);
+            f(*lhs);
+            f(*rhs);
+        }
+        Instr::Compare { dst, lhs, rhs, .. } => {
+            f(*dst);
+            f(*lhs);
+            f(*rhs);
+        }
+        Instr::LoadLocal { dst, .. } => f(*dst),
+        Instr::StoreLocal { src, .. } => f(*src),
+        Instr::LoadIndexed { dst, index, .. } => {
+            f(*dst);
+            f(*index);
+        }
+        Instr::StoreIndexed { index, src, .. } => {
+            f(*index);
+            f(*src);
+        }
+        Instr::AddressOf { dst, .. } => f(*dst),
+        Instr::Load { dst, addr } => {
+            f(*dst);
+            f(*addr);
+        }
+        Instr::Store { addr, src } => {
+            f(*addr);
+            f(*src);
+        }
+        Instr::Syscall { dst, args } => {
+            f(*dst);
+            for a in args {
+                f(*a);
+            }
+        }
+        Instr::Call { dst, args, .. } => {
+            if let Some(d) = dst {
+                f(*d);
+            }
+            for a in args {
+                f(*a);
+            }
+        }
+        Instr::Label(_) | Instr::Jump(_) => {}
+        Instr::JumpIfZero { cond, .. } | Instr::JumpIfNotZero { cond, .. } => f(*cond),
+        Instr::Return(v) => {
+            if let Some(v) = v {
+                f(*v);
+            }
+        }
+    }
+}
+
+/// Computes each virtual register's live range as [first occurrence, last
+/// occurrence] by textual instruction position. This is a conservative
+/// approximation (real liveness would follow control flow precisely), but
+/// it's always *safe*: at worst it overestimates how long a value needs to
+/// stay live, which only costs a missed optimization, never correctness.
+fn compute_intervals(body: &[Instr], vreg_count: u32) -> Vec<Interval> {
+    let mut first: Vec<Option<usize>> = vec![None; vreg_count as usize];
+    let mut last: Vec<Option<usize>> = vec![None; vreg_count as usize];
+
+    for (i, instr) in body.iter().enumerate() {
+        for_each_vreg(instr, |v| {
+            let idx = v.0 as usize;
+            if first[idx].is_none() {
+                first[idx] = Some(i);
+            }
+            last[idx] = Some(i);
+        });
+    }
+
+    (0..vreg_count)
+        .filter_map(|id| {
+            let start = first[id as usize]?;
+            let end = last[id as usize]?;
+            Some(Interval {
+                vreg: VReg(id),
+                start,
+                end,
+            })
+        })
+        .collect()
+}
+
+pub fn allocate(body: &[Instr], vreg_count: u32, num_registers: u32) -> Allocation {
+    let mut intervals = compute_intervals(body, vreg_count);
+    intervals.sort_by_key(|iv| iv.start);
+
+    let mut locations: Vec<Location> = (0..vreg_count).map(|_| Location::Spill(0)).collect();
+    let mut used_registers = vec![false; num_registers as usize];
+    let mut next_spill_slot = 0usize;
+
+    // Live intervals currently holding a register: (end, register slot, vreg).
+    let mut active: Vec<(usize, u32, VReg)> = Vec::new();
+
+    for iv in intervals {
+        active.retain(|&(end, _, _)| end >= iv.start);
+
+        let used_slots: std::collections::HashSet<u32> =
+            active.iter().map(|&(_, slot, _)| slot).collect();
+        let free_slot = (0..num_registers).find(|slot| !used_slots.contains(slot));
+
+        if let Some(slot) = free_slot {
+            locations[iv.vreg.0 as usize] = Location::Register(slot);
+            used_registers[slot as usize] = true;
+            active.push((iv.end, slot, iv.vreg));
+        } else {
+            // No free register - spill whichever of "this interval" or the
+            // active interval ending furthest in the future is less
+            // valuable to keep in a register (classic linear-scan
+            // heuristic: prefer to keep the shorter-lived value in a
+            // register, since it'll free up sooner for reuse).
+            active.sort_by_key(|&(end, _, _)| end);
+            match active.last().copied() {
+                Some((worst_end, worst_slot, worst_vreg)) if worst_end > iv.end => {
+                    locations[worst_vreg.0 as usize] = Location::Spill(next_spill_slot);
+                    next_spill_slot += 1;
+                    active.pop();
+
+                    locations[iv.vreg.0 as usize] = Location::Register(worst_slot);
+                    active.push((iv.end, worst_slot, iv.vreg));
+                }
+                _ => {
+                    locations[iv.vreg.0 as usize] = Location::Spill(next_spill_slot);
+                    next_spill_slot += 1;
+                }
+            }
+        }
+    }
+
+    Allocation {
+        locations,
+        used_registers,
+        spill_count: next_spill_slot,
+    }
+}

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -33,6 +33,7 @@ EXAMPLES=(
   "examples/optimization/fold_const.cfy|16"
   "examples/optimization/sub_expr.cfy|49"
   "examples/optimization/repeat_shifts.cfy|40"
+  "examples/optimization/tail_calls.cfy|0"
 )
 
 echo "Building comfyc..."

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -29,6 +29,7 @@ EXAMPLES=(
   "examples/variables/mutability.cfy|41"
   "examples/variables/syscall_expr.cfy|0"
   "examples/variables/syscall_expr_pid.cfy|skip"
+  "examples/optimization/opt_control_flow.cfy|42"
 )
 
 echo "Building comfyc..."

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -31,6 +31,7 @@ EXAMPLES=(
   "examples/variables/syscall_expr_pid.cfy|skip"
   "examples/optimization/opt_control_flow.cfy|42"
   "examples/optimization/fold_const.cfy|16"
+  "examples/optimization/sub_expr.cfy|49"
 )
 
 echo "Building comfyc..."

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -32,6 +32,7 @@ EXAMPLES=(
   "examples/optimization/opt_control_flow.cfy|42"
   "examples/optimization/fold_const.cfy|16"
   "examples/optimization/sub_expr.cfy|49"
+  "examples/optimization/repeat_shifts.cfy|40"
 )
 
 echo "Building comfyc..."

--- a/util/test_examples.sh
+++ b/util/test_examples.sh
@@ -30,6 +30,7 @@ EXAMPLES=(
   "examples/variables/syscall_expr.cfy|0"
   "examples/variables/syscall_expr_pid.cfy|skip"
   "examples/optimization/opt_control_flow.cfy|42"
+  "examples/optimization/fold_const.cfy|16"
 )
 
 echo "Building comfyc..."


### PR DESCRIPTION
## Summary

- propragate constants
- fold branches
- eliminate common subexpressions
- remove dead stores
- remove unused pure instrs
- remove unreachable code
- repeat shifts

## Related issue(s)

Closes #146

## Area

<!-- e.g. area: parser, area: codegen-arm32, area: ir, docs, ci, etc. -->

## Checklist

- [x] `cargo build` succeeds
- [x] Added/updated an example in `examples/` if this changes or adds language surface
- [x] Updated `README.md` (roadmap/language surface section) if applicable
- [x] This is **not** a breaking change to existing `.cfy` syntax/behavior, or it's labeled `breaking-change` and explained below

## Notes for reviewers

<!-- Anything that needs extra attention, open questions, follow-up work, etc. -->
